### PR TITLE
fix: stash parent handle in NeedsParentSync; document residual delete…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,35 @@ Inspired by Dgraph's mmap file implementation in [ristretto](https://github.com/
 A file-backed memory map exposes the kernel's view of an inode as a `&[u8]`/`&mut [u8]`. That makes it easy to reach for, but it also means UB the moment another actor truncates, unlinks, or rewrites the file out from under the mapping — SIGBUS on Unix, mapping detachment on Windows, silent torn reads in either. `fmmap` raises a safe API over `memmapix` by treating those concerns as first-class:
 
 - **Auto-acquired advisory lock** on every constructor — exclusive on writable maps, shared on read-only / COW maps. Aliased writable mappings of the same file (and mut-then-COW) are rejected up front.
-- **Identity-checked deletion** (POSIX `dev`+`ino`). Captured at open, used by every unlink path to refuse to delete a file someone else has swapped in at the path. Windows on stable Rust falls back to "path resolves" semantics — `file_index` is still nightly-only — and the residual race window is documented.
+- **Best-effort path-reuse mitigation on deletion**. Identity is captured at open and re-checked before every unlink so a file someone else has swapped in at the path won't be silently deleted. POSIX uses `(st_dev, st_ino)`; Windows uses `(volumeSerial, fileIndex)` from `GetFileInformationByHandle` (via `windows-sys`, no nightly required). **This is not an absolute guarantee** — see the [path-reuse limitations](#path-reuse-limitations) below.
 - **Pre-validated mapping ranges**. Constructors reject `offset`/`len` overflow, ranges past EOF, and effective lengths > `isize::MAX` *before* any destructive `set_len` runs, so an invalid `Options` never zeroes or extends an existing file.
-- **Crash-durable unlink**. The parent directory is pinned by a handle opened *before* `remove_file`, then fsynced through that same handle, so a parent rename between unlink and fsync can't direct the durability to the wrong inode.
+- **Crash-durable unlink**. The parent directory is pinned by a handle opened *before* `remove_file`, then fsynced through that same handle. Failed-fsync retries fsync the *same* handle (not a freshly-opened parent), so a parent rename between unlink and fsync can't direct the durability to the wrong inode.
 - **Reentrant-safe lock methods**. `LockFileEx` deadlocks on the same Windows handle; `lock` / `lock_shared` short-circuit when the desired state is already held. The lock methods take `&mut self` so single-owner serialization is enforced by the borrow checker.
 - **Poison-safe truncate / freeze**. A failed truncate marks the wrapper poisoned; subsequent reads return `&[]` and writes/flushes/freezes return `Err` rather than handing back an anonymous-mapped placeholder pretending to be the original file.
 
 `std` plus tokio and smol are first-class. The async surface is built from the same set of macros, so adding a new runtime is small and mechanical — see `fmmap/src/disk/{tokio,smol}_impl.rs`.
 
+### Path-reuse limitations
+
+Identity-checked deletion is best-effort and the rest of the safety surface assumes a non-adversarial filesystem. Specifically:
+
+- **One-syscall probe→unlink TOCTOU.** Between the identity probe and the actual `remove_file`, an attacker with rights to mutate the parent directory could swap the entry. Closing this fully needs atomic primitives that `std` doesn't expose — `unlinkat(parent_fd, basename, 0)` after `fstatat` on POSIX, or `SetFileInformationByHandle(FileDispositionInfo)` on a `FILE_SHARE_DELETE` handle on Windows. The narrow window (one syscall) is dramatically smaller than the broad handle-drop-to-retry window the identity check *does* close, but it isn't zero.
+- **POSIX inode recycling.** The kernel can reuse recently-freed inode numbers; on small-id filesystems (tmpfs in particular) a fresh file may occasionally land on the original inode, defeating the comparison. Holding any other handle on the original inode pins it (we keep the parent dir handle alive across the unlink, which already pins the parent inode).
+- **External NotFound never claims durable deletion.** When the path probe returns `NotFound` (the file is missing at probe time, or `unlinkat` finds nothing), fmmap stays in `NeedsUnlink` and surfaces `NotFound` rather than claiming the deletion succeeded. Earlier versions used a `nlink == 0` check to converge on "durably gone", but that signal can't distinguish "unlink in our parent" from "rename + unlink in another parent" — and our parent's fsync only commits the former. Drop's best-effort fsync of our parent still helps in the typical "external `rm` in our parent" case, but the API contract is now: explicit `remove()` only returns `Ok` if fmmap itself observed `unlinkat` succeed in the parent it then fsynced. Callers who want crash-durable identity-checked deletion under concurrent rename should serialize external mutations or `fsync` the relevant parents themselves.
+
+### Async wrapper EMFILE on consuming `drop_remove`
+
+On smol, `AsyncMmapFileMut::drop_remove(self)` allocates a duplicate file descriptor for the inode pin (smol's `async-fs::File` has no `into_std()` equivalent). Under fd pressure (`EMFILE`) the dup fails and `drop_remove` returns `Err` deterministically — the file is *not* deleted, no hidden Drop-time retry attempts to clean up. Callers can recover by calling `std::fs::remove_file(path)` themselves, or use `AsyncMmapFileMut::remove(&mut self)` which preserves `self` for an explicit retry once fd pressure subsides.
+
+Tokio's wrapper extracts the inode pin via `tokio::fs::File::into_std()` (no fd allocation), so EMFILE doesn't apply on tokio.
+
+If your threat model includes an active local adversary, do not rely on identity-checked delete for safety — perform the cleanup yourself with whatever atomic primitives your platform provides.
+
 ## Features
 - [x] file-backed memory maps with auto-locked construction
 - [x] read-only / copy-on-write / mutable / executable maps
-- [x] identity-checked, path-reuse-safe deletion
-- [x] crash-durable unlink with pre-opened parent fsync
+- [x] best-effort path-reuse mitigation on deletion (POSIX dev+ino, Windows volume+fileIndex via `windows-sys`; see [Design](#design) for limits)
+- [x] crash-durable unlink with pre-opened parent fsync (the same handle is reused on retry)
 - [x] pre-validated mapping ranges (rejects past-EOF and `> isize::MAX` before any destructive `set_len`)
 - [x] poison-safe `truncate` / `freeze` / `freeze_exec`
 - [x] synchronous and asynchronous flushing

--- a/fmmap/Cargo.toml
+++ b/fmmap/Cargo.toml
@@ -31,6 +31,21 @@ pin-project-lite = { version = "0.2", optional = true }
 smol = { version = "2", optional = true }
 tokio = { version = "1", optional = true }
 
+# Unix: rustix is used for the safe POSIX path of identity-checked
+# delete (`statat`/`unlinkat` against an open parent fd) and for atomic
+# CLOEXEC fd duplication (`fcntl_dupfd_cloexec`). `rustix` returns an
+# `OwnedFd` directly, which avoids the borrowed-vs-owned hazard of
+# `libc::fcntl` + `File::from_raw_fd`.
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1", features = ["fs"] }
+
+# Windows: `GetFileInformationByHandle` for real (volume serial, file
+# index) identity on stable Rust (no nightly `windows_by_handle`), plus
+# `DuplicateHandle` for the async-handle identity capture (same
+# panic-safety reasoning as `libc::dup` on Unix).
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Threading"] }
+
 [dev-dependencies]
 ctor = "0.12"
 criterion = "0.8"

--- a/fmmap/src/disk.rs
+++ b/fmmap/src/disk.rs
@@ -678,7 +678,26 @@ cfg_async! {
           Ok(())
         }
 
-        /// Remove the underlying file
+        /// Remove the underlying file.
+        ///
+        /// # Durability semantics
+        ///
+        /// On success, the unlink is committed AND the parent directory's
+        /// metadata is fsynced (crash-durable). On parent-fsync failure
+        /// after a successful unlink, the unlink is committed but not
+        /// crash-durable; the raw API has no `NeedsParentSync` state
+        /// machine, so the caller cannot retry fsync on the original
+        /// parent inode. **For crash-durable identity-checked deletion,
+        /// prefer the wrapper API** (`AsyncMmapFileMut::drop_remove` /
+        /// `AsyncMmapFileMut::remove`) which carries the parent handle
+        /// in `PendingDelete::NeedsParentSync` and retries on the same
+        /// inode.
+        ///
+        /// On smol under fd pressure (EMFILE), the inode-pin dup may
+        /// fail and the file is not deleted; `self` is consumed and the
+        /// caller has no retry path. tokio uses `into_std` to extract
+        /// the pin without allocating an fd, so no EMFILE failure mode
+        /// applies on tokio.
         ///
         /// # Example
         ///
@@ -702,47 +721,53 @@ cfg_async! {
         async fn drop_remove(self) -> crate::error::Result<()> {
           let path = self.path;
           let identity = self.file_identity;
+          // Take ownership of the inode pin via runtime-specific
+          // helper. tokio uses `tokio::fs::File::into_std` (no fd
+          // alloc — closes the EMFILE-during-drop_remove window). smol
+          // falls back to `fcntl_dupfd_cloexec` because async-fs has
+          // no into_std equivalent; on EMFILE the raw API returns Err
+          // and the file is not deleted (documented limitation; the
+          // wrapper's `drop_remove`/`remove` route through their own
+          // recovery path that retries via Drop).
           drop(self.mmap);
-          drop(self.file);
-          // Pre-open the parent dir handle so the post-unlink fsync hits
-          // the *original* parent inode even if the path's parent is
-          // renamed mid-operation.
-          let parent_handle = crate::utils::open_parent_for_sync(&path)?;
-          // See sync raw `drop_remove`: identity-check before unlink so a
-          // path-reused file isn't deleted in the window between handle
-          // drop and `remove_file`. Distinguish "path missing" (let the
-          // unlink return NotFound below) from "path-reuse mismatch"
-          // (refuse delete with a tagged error).
-          match std::fs::metadata(&path) {
-            Err(e) if e.kind() == ErrorKind::NotFound => return Err(e),
-            Err(e) => return Err(e),
-            Ok(probe) => {
-              let probe_id = crate::utils::FileIdentity::from_metadata(&probe);
-              if !identity.is_known_equal(&probe_id) {
-                return Err(Error::other(format!(
-                  "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink, or platform identity unavailable)",
-                  path.display(),
-                )));
+          #[cfg(unix)]
+          let inode_pin: Option<std::fs::File> = Some(extract_inode_pin(self.file).await?);
+          #[cfg(not(unix))]
+          let inode_pin: Option<std::fs::File> = {
+            drop(self.file);
+            None
+          };
+          // Run the entire blocking sequence on the runtime's
+          // blocking-task pool, matching the wrapper-level async paths
+          // so a slow filesystem can't stall the executor.
+          run_blocking_io(move || -> crate::error::Result<()> {
+            let _inode_pin = inode_pin;
+            let parent_handle = crate::utils::open_parent_for_sync(&path)?;
+            match crate::utils::identity_at_or_path(&parent_handle, &path) {
+              Err(e) if e.kind() == ErrorKind::NotFound => return Err(e),
+              Err(e) => return Err(e),
+              Ok(probe_id) => {
+                if !identity.is_known_equal(&probe_id) {
+                  return Err(Error::other(format!(
+                    "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink)",
+                    path.display(),
+                  )));
+                }
               }
             }
-          }
-          // Initial-call semantics: NotFound is the user's error.
-          // Idempotency for the failed-mid-way retry path lives at the
-          // wrapper layer.
-          remove_file(&path).await?;
-          // Fsync the original parent inode handle. Tag a parent-sync
-          // failure so the caller can tell unlink-failed from
-          // unlink-succeeded-but-parent-fsync-failed.
-          crate::utils::sync_parent_handle(&parent_handle).map_err(|e| {
-            Error::new(
-              e.kind(),
-              format!(
-                "file '{}' unlinked but parent dir fsync failed: {e}; \
-                 the unlink is committed but not yet crash-durable",
-                path.display(),
-              ),
-            )
+            crate::utils::unlink_at_or_path(&parent_handle, &path, identity)?;
+            crate::utils::sync_parent_handle(&parent_handle).map_err(|e| {
+              Error::new(
+                e.kind(),
+                format!(
+                  "file '{}' unlinked but parent dir fsync failed: {e}; \
+                   the unlink is committed but not yet crash-durable",
+                  path.display(),
+                ),
+              )
+            })
           })
+          .await
         }
 
         /// Close and truncate the underlying file
@@ -1459,7 +1484,28 @@ cfg_async! {
             sync_parent_async(&path).await?;
           }
 
-          let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata().await?);
+          // Capture identity from the *already-open* async handle so
+          // an attacker can't race a path swap between our open and the
+          // identity probe. tokio::fs::File / smol::fs::File both impl
+          // AsRawFd / AsRawHandle, so we read the raw fd/handle and
+          // call the appropriate platform identity API on it.
+          let file_identity = {
+            #[cfg(unix)]
+            {
+              use std::os::fd::AsRawFd;
+              // SAFETY: `file` is alive for the duration of this call;
+              // we hold it across the unsafe call.
+              unsafe { crate::utils::FileIdentity::from_raw_fd(file.as_raw_fd()) }?
+            }
+            #[cfg(windows)]
+            {
+              use std::os::windows::io::AsRawHandle;
+              // SAFETY: `file` is alive for the duration of this call.
+              unsafe { crate::utils::FileIdentity::from_raw_handle(file.as_raw_handle()) }?
+            }
+            #[cfg(not(any(unix, windows)))]
+            crate::utils::FileIdentity::from_path(path_ref)?
+          };
           let mmap = unsafe {
             match &opts_bk {
               None => MmapMut::map_mut(&file)?,
@@ -1540,7 +1586,28 @@ cfg_async! {
             sync_parent_async(&path).await?;
           }
 
-          let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata().await?);
+          // Capture identity from the *already-open* async handle so
+          // an attacker can't race a path swap between our open and the
+          // identity probe. tokio::fs::File / smol::fs::File both impl
+          // AsRawFd / AsRawHandle, so we read the raw fd/handle and
+          // call the appropriate platform identity API on it.
+          let file_identity = {
+            #[cfg(unix)]
+            {
+              use std::os::fd::AsRawFd;
+              // SAFETY: `file` is alive for the duration of this call;
+              // we hold it across the unsafe call.
+              unsafe { crate::utils::FileIdentity::from_raw_fd(file.as_raw_fd()) }?
+            }
+            #[cfg(windows)]
+            {
+              use std::os::windows::io::AsRawHandle;
+              // SAFETY: `file` is alive for the duration of this call.
+              unsafe { crate::utils::FileIdentity::from_raw_handle(file.as_raw_handle()) }?
+            }
+            #[cfg(not(any(unix, windows)))]
+            crate::utils::FileIdentity::from_path(path_ref)?
+          };
           let mmap = match &opts_bk {
             None => unsafe {
               MmapMut::map_mut(&file)?
@@ -1601,7 +1668,28 @@ cfg_async! {
               (mmap, Some(opts_bk), offset, len)
             }
           };
-          let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata().await?);
+          // Capture identity from the *already-open* async handle so
+          // an attacker can't race a path swap between our open and the
+          // identity probe. tokio::fs::File / smol::fs::File both impl
+          // AsRawFd / AsRawHandle, so we read the raw fd/handle and
+          // call the appropriate platform identity API on it.
+          let file_identity = {
+            #[cfg(unix)]
+            {
+              use std::os::fd::AsRawFd;
+              // SAFETY: `file` is alive for the duration of this call;
+              // we hold it across the unsafe call.
+              unsafe { crate::utils::FileIdentity::from_raw_fd(file.as_raw_fd()) }?
+            }
+            #[cfg(windows)]
+            {
+              use std::os::windows::io::AsRawHandle;
+              // SAFETY: `file` is alive for the duration of this call.
+              unsafe { crate::utils::FileIdentity::from_raw_handle(file.as_raw_handle()) }?
+            }
+            #[cfg(not(any(unix, windows)))]
+            crate::utils::FileIdentity::from_path(path_ref)?
+          };
           Ok(Self {
             mmap,
             file,
@@ -1642,7 +1730,28 @@ cfg_async! {
             }
           };
 
-          let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata().await?);
+          // Capture identity from the *already-open* async handle so
+          // an attacker can't race a path swap between our open and the
+          // identity probe. tokio::fs::File / smol::fs::File both impl
+          // AsRawFd / AsRawHandle, so we read the raw fd/handle and
+          // call the appropriate platform identity API on it.
+          let file_identity = {
+            #[cfg(unix)]
+            {
+              use std::os::fd::AsRawFd;
+              // SAFETY: `file` is alive for the duration of this call;
+              // we hold it across the unsafe call.
+              unsafe { crate::utils::FileIdentity::from_raw_fd(file.as_raw_fd()) }?
+            }
+            #[cfg(windows)]
+            {
+              use std::os::windows::io::AsRawHandle;
+              // SAFETY: `file` is alive for the duration of this call.
+              unsafe { crate::utils::FileIdentity::from_raw_handle(file.as_raw_handle()) }?
+            }
+            #[cfg(not(any(unix, windows)))]
+            crate::utils::FileIdentity::from_path(path_ref)?
+          };
           Ok(Self {
             mmap,
             file,

--- a/fmmap/src/disk/smol_impl.rs
+++ b/fmmap/src/disk/smol_impl.rs
@@ -10,10 +10,45 @@ use crate::{
 };
 
 use memmapix::{Mmap, MmapMut, MmapOptions};
-use smol::fs::{remove_file, File};
+use smol::fs::File;
 use std::path::{Path, PathBuf};
 
 use crate::disk::remmap;
+
+/// Run a blocking IO closure off the smol executor; mirrors the helper
+/// in `mmap_file::smol_impl`.
+async fn run_blocking_io<F, T>(f: F) -> T
+where
+  F: FnOnce() -> T + Send + 'static,
+  T: Send + 'static,
+{
+  smol::unblock(f).await
+}
+
+/// Convert the runtime-specific async file into an owned
+/// `std::fs::File` to use as the inode pin during durable delete.
+///
+/// Smol uses `async-fs`, which does **not** expose an `into_std`
+/// equivalent — its inner `std::fs::File` is held by an `Arc<File>`
+/// shared with a background `Unblock` task and cannot be unwrapped
+/// without an upstream API change. The fallback is to dup the fd via
+/// `fcntl_dupfd_cloexec`. Under fd pressure (EMFILE) this returns
+/// Err; the caller's raw `AsyncDiskMmapFileMut::drop_remove(self)`
+/// will then surface the error and the file will not be deleted.
+/// The wrapper-level `AsyncMmapFileMut::drop_remove` and `remove`
+/// have a `remove_on_drop = true` recovery path that lets `Drop`
+/// retry the dup once fds free up.
+#[cfg(unix)]
+async fn extract_inode_pin(file: File) -> std::io::Result<std::fs::File> {
+  use std::os::fd::{AsRawFd, BorrowedFd};
+  let raw = file.as_raw_fd();
+  // SAFETY: file is alive for the duration of this borrow.
+  let borrowed = unsafe { BorrowedFd::borrow_raw(raw) };
+  let owned = rustix::io::fcntl_dupfd_cloexec(borrowed, 0).map_err(std::io::Error::from)?;
+  // dup is independent now; close the async wrapper.
+  drop(file);
+  Ok(std::fs::File::from(owned))
+}
 
 declare_and_impl_async_fmmap_file!("smol_async", "smol", "smol", File);
 

--- a/fmmap/src/disk/sync_impl.rs
+++ b/fmmap/src/disk/sync_impl.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use memmapix::{Mmap, MmapMut, MmapOptions};
 use std::{
-  fs::{remove_file, File},
+  fs::File,
   path::{Path, PathBuf},
 };
 
@@ -381,7 +381,31 @@ impl MmapFileMutExt for DiskMmapFileMut {
     }
   }
 
-  /// Remove the underlying file
+  /// Remove the underlying file.
+  ///
+  /// # Durability semantics
+  ///
+  /// On success, the unlink is committed to disk: `unlinkat` succeeded
+  /// AND the parent directory's metadata was fsynced. On error, behavior
+  /// depends on which step failed:
+  ///
+  /// - **Identity / probe failure**: nothing was unlinked. The inode
+  ///   pin is dropped on return; the caller cannot retry.
+  /// - **Unlink failure**: nothing was unlinked. Same.
+  /// - **Parent-fsync failure after a successful unlink**: the unlink
+  ///   *is* committed (the directory entry is gone) but is not yet
+  ///   crash-durable. The error message reflects this. The raw API
+  ///   has no `NeedsParentSync` state machine — the parent handle is
+  ///   dropped on return, so the caller cannot retry the fsync on the
+  ///   *original* parent inode (a parent rename between the failed
+  ///   call and any later `std::fs::File::open(parent).sync_all()` could
+  ///   land on the wrong directory).
+  ///
+  /// **For crash-durable identity-checked deletion, prefer the wrapper
+  /// API** (`MmapFileMut::drop_remove` / `MmapFileMut::remove` and the
+  /// async equivalents). The wrapper carries the parent handle in
+  /// `PendingDelete::NeedsParentSync` and retries fsync on the same
+  /// inode.
   ///
   /// # Examples
   ///
@@ -404,7 +428,18 @@ impl MmapFileMutExt for DiskMmapFileMut {
     let path = self.path;
     let identity = self.file_identity;
     drop(self.mmap);
-    drop(self.file);
+    // Keep `self.file` alive across probe + unlink on POSIX so the
+    // inode it refers to cannot be recycled (which would let a fresh
+    // file at the same path pass the (dev, ino) identity check).
+    // Windows: the file must be dropped before unlink because it was
+    // opened without `FILE_SHARE_DELETE`.
+    #[cfg(unix)]
+    let _inode_pin: Option<File> = Some(self.file);
+    #[cfg(not(unix))]
+    let _inode_pin: Option<File> = {
+      drop(self.file);
+      None
+    };
     // Pre-open the parent dir handle so the post-unlink fsync commits
     // metadata on the *original* parent inode even if the path's parent
     // is renamed mid-operation.
@@ -414,24 +449,22 @@ impl MmapFileMutExt for DiskMmapFileMut {
     // before unlinking, distinguishing "path missing" from "path-reuse
     // mismatch": the former is the same NotFound semantics callers had
     // before identity tracking; the latter must refuse the delete.
-    match std::fs::metadata(&path) {
+    match crate::utils::identity_at_or_path(&parent_handle, &path) {
       Err(e) if e.kind() == ErrorKind::NotFound => return Err(e),
       Err(e) => return Err(e),
-      Ok(probe) => {
-        let probe_id = crate::utils::FileIdentity::from_metadata(&probe);
+      Ok(probe_id) => {
         if !identity.is_known_equal(&probe_id) {
           return Err(Error::other(format!(
-            "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink, or platform identity unavailable)",
+            "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink)",
             path.display(),
           )));
         }
       }
     }
-    // Initial-call semantics: a missing file is the user's error; we do
-    // NOT treat NotFound as success here. (Idempotency for the
-    // post-failure-pre-sync window lives at the wrapper layer where
-    // `pending_drop_remove` is consulted.)
-    remove_file(&path)?;
+    // Bind the unlink to parent_handle on POSIX so the subsequent
+    // sync_parent_handle is durable for the directory the entry was
+    // actually removed from.
+    crate::utils::unlink_at_or_path(&parent_handle, &path, identity)?;
     // Sync the original parent inode handle. Tag a parent-sync failure
     // so the caller using the raw API can tell unlink-failed from
     // unlink-succeeded-but-parent-fsync-failed.
@@ -1048,7 +1081,7 @@ impl DiskMmapFileMut {
       sync_file_and_parent(&file, path_ref)?;
     }
 
-    let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata()?);
+    let file_identity = crate::utils::FileIdentity::from_file(&file)?;
     let mmap = unsafe {
       match &opts_bk {
         None => MmapMut::map_mut(&file)?,
@@ -1126,7 +1159,7 @@ impl DiskMmapFileMut {
       sync_file_and_parent(&file, path_ref)?;
     }
 
-    let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata()?);
+    let file_identity = crate::utils::FileIdentity::from_file(&file)?;
     let mmap = unsafe {
       match &opts_bk {
         None => MmapMut::map_mut(&file)?,
@@ -1180,7 +1213,7 @@ impl DiskMmapFileMut {
       }
     };
 
-    let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata()?);
+    let file_identity = crate::utils::FileIdentity::from_file(&file)?;
     Ok(Self {
       mmap,
       file,
@@ -1216,7 +1249,7 @@ impl DiskMmapFileMut {
       }
     };
 
-    let file_identity = crate::utils::FileIdentity::from_metadata(&file.metadata()?);
+    let file_identity = crate::utils::FileIdentity::from_file(&file)?;
     Ok(Self {
       mmap,
       file,

--- a/fmmap/src/disk/tokio_impl.rs
+++ b/fmmap/src/disk/tokio_impl.rs
@@ -11,9 +11,32 @@ use crate::{
 
 use memmapix::{Mmap, MmapMut, MmapOptions};
 use std::path::{Path, PathBuf};
-use tokio::fs::{remove_file, File};
+use tokio::fs::File;
 
 use crate::disk::remmap;
+
+/// Run a blocking IO closure on tokio's blocking thread pool. Used by
+/// the raw async durable-delete path; mirrors the helper in
+/// `mmap_file::tokio_impl`.
+async fn run_blocking_io<F, T>(f: F) -> T
+where
+  F: FnOnce() -> T + Send + 'static,
+  T: Send + 'static,
+{
+  match tokio::task::spawn_blocking(f).await {
+    Ok(r) => r,
+    Err(e) => std::panic::resume_unwind(e.into_panic()),
+  }
+}
+
+/// Convert the runtime-specific async file into an owned
+/// `std::fs::File` to use as the inode pin during durable delete.
+/// `tokio::fs::File::into_std` moves the underlying `std::fs::File`
+/// out without allocating a new fd — no EMFILE risk.
+#[cfg(unix)]
+async fn extract_inode_pin(file: File) -> std::io::Result<std::fs::File> {
+  Ok(file.into_std().await)
+}
 
 declare_and_impl_async_fmmap_file!("tokio_async", "tokio_test", "tokio", File);
 

--- a/fmmap/src/mmap_file.rs
+++ b/fmmap/src/mmap_file.rs
@@ -66,16 +66,39 @@ pub(crate) enum PendingDelete {
   /// recorded *before* the original handle was dropped, so retry can
   /// re-open the path and confirm that it still names the same inode
   /// (path-reuse safety) before unlinking.
+  ///
+  /// On POSIX, `pin` is an `F_DUPFD_CLOEXEC`-duplicate of the original
+  /// file descriptor, held alive across every retry. The kernel cannot
+  /// recycle `(dev, ino)` while ANY descriptor referring to that
+  /// open-file description is alive, so the identity check stays valid
+  /// across as many retries as the user attempts. Without this, a
+  /// retry on a tmpfs-style filesystem (which recycles inodes
+  /// aggressively after the last fd closes) could match `(dev, ino)`
+  /// against a totally unrelated file that happened to land at the
+  /// same path with the same recycled inode number — and unlink it.
   NeedsUnlink {
     path: ::std::path::PathBuf,
     identity: crate::utils::FileIdentity,
+    #[cfg(unix)]
+    pin: std::fs::File,
   },
   /// Either `remove_file` succeeded but the parent fsync did not, or
   /// `remove_file` reported `NotFound` (the file was already gone before
   /// our call). Either way, the inode is presumed gone; retry MUST NOT
   /// call `remove_file` again — that could delete a new occupant of the
   /// same path. Only the parent fsync remains.
-  NeedsParentSync(::std::path::PathBuf),
+  ///
+  /// `parent_handle` holds a `File` opened on the *original* parent
+  /// directory inode (captured before unlink). Retry fsyncs THAT handle,
+  /// not a freshly-opened one — without that, a parent-rename between
+  /// unlink and retry would silently fsync the wrong inode and the
+  /// wrapper would clear the pending state while the original unlink
+  /// was never made crash-durable. `path` is retained for diagnostics
+  /// only.
+  NeedsParentSync {
+    path: ::std::path::PathBuf,
+    parent_handle: std::fs::File,
+  },
 }
 
 #[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
@@ -84,7 +107,7 @@ impl PendingDelete {
   #[allow(dead_code)]
   pub(crate) fn path(&self) -> &::std::path::Path {
     match self {
-      Self::NeedsUnlink { path, .. } | Self::NeedsParentSync(path) => path,
+      Self::NeedsUnlink { path, .. } | Self::NeedsParentSync { path, .. } => path,
     }
   }
 }
@@ -96,27 +119,67 @@ impl PendingDelete {
 /// `NeedsUnlink` carries a `FileIdentity` captured at construction time,
 /// so even though the original `File` handle is gone we can still verify
 /// the path still names the same inode before unlinking. If identity
-/// matches: unlink, then parent fsync. If not (path was reused): leave
-/// alone. Either way we fsync the parent.
+/// matches: unlink, then parent fsync (on a freshly-opened parent — we
+/// don't have a stashed handle on this branch). If not (path was reused):
+/// leave alone.
+///
+/// `NeedsParentSync` carries the pre-opened parent dir handle from the
+/// initial unlink; we fsync THAT handle so the durability commits to the
+/// inode that contained our entry, even if the parent path has since
+/// been renamed.
 ///
 /// All errors are swallowed because `Drop` cannot return a `Result`.
 #[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
 pub(crate) fn drop_complete_pending_delete(pending: PendingDelete) {
-  let path = match &pending {
-    PendingDelete::NeedsUnlink { path, identity } => {
-      if identity.matches_path(path) {
-        let _ = std::fs::remove_file(path);
+  match pending {
+    PendingDelete::NeedsUnlink {
+      path,
+      identity,
+      #[cfg(unix)]
+      pin,
+    } => {
+      // Bind the probe + unlink + fsync to the same parent dir handle
+      // (POSIX `fstatat` + `unlinkat` against an open parent fd).
+      // Without this, a parent rename between probe and remove could
+      // let us unlink an entry in a different directory and then fsync
+      // the wrong parent. If we can't even open the parent, fall
+      // through to a best-effort path-based parent fsync — never a
+      // path-based unlink.
+      //
+      // `pin` (POSIX) is an alive dup of the original fd, so the
+      // kernel cannot recycle `(dev, ino)` while we run the probe and
+      // unlink below. Held to function exit — drop it AFTER the unlink
+      // call returns.
+      #[cfg(unix)]
+      let _inode_pin = pin;
+      let parent_handle = match crate::utils::open_parent_for_sync(&path) {
+        Ok(h) => h,
+        Err(_) => {
+          let parent = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+            _ => ::std::path::PathBuf::from("."),
+          };
+          let _ = crate::utils::sync_directory(&parent);
+          return;
+        }
+      };
+      if let Ok(probe) = crate::utils::identity_at_or_path(&parent_handle, &path) {
+        if identity.is_known_equal(&probe) {
+          let _ = crate::utils::unlink_at_or_path(&parent_handle, &path, identity);
+        }
+        // Identity mismatch → path was reused, do not unlink.
       }
-      // Identity mismatch → path was reused, do not unlink.
-      path.clone()
+      // Identity probe failure (path missing, symlink, etc.) → skip
+      // unlink. Either way, fsync the parent we opened.
+      let _ = crate::utils::sync_parent_handle(&parent_handle);
     }
-    PendingDelete::NeedsParentSync(p) => p.clone(),
-  };
-  let parent = match path.parent() {
-    Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
-    _ => ::std::path::PathBuf::from("."),
-  };
-  let _ = crate::utils::sync_directory(&parent);
+    PendingDelete::NeedsParentSync {
+      path: _,
+      parent_handle,
+    } => {
+      let _ = crate::utils::sync_parent_handle(&parent_handle);
+    }
+  }
 }
 
 /// Drop-time best-effort cleanup for the opt-in `remove_on_drop` /
@@ -148,23 +211,75 @@ pub(crate) fn drop_unlink_durably(path: &::std::path::Path) {
 }
 
 /// Identity-checked Drop-time unlink for the direct `remove_on_drop`
-/// path: we still hold an identity captured from the inner (recorded at
-/// construction). If `path` still names the same inode (path-reuse-free),
-/// unlink it; otherwise leave alone. Then fsync the parent. All errors
-/// swallowed because `Drop` cannot return a `Result`.
+/// path. Uses the same parent-bound sequence as `initial_remove_durably`
+/// — open the parent dir handle once, probe identity bound to it
+/// (`fstatat` on POSIX), unlink bound to it (`unlinkat`), fsync the
+/// same handle. `inode_pin` (POSIX only — Windows passes `None`) is
+/// the original file handle, held alive through probe + unlink so the
+/// `(dev, ino)` we compare against can't be recycled to a replacement.
+/// All errors swallowed because `Drop` cannot return a `Result`.
 #[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
 pub(crate) fn drop_unlink_with_identity(
   path: &::std::path::Path,
   identity: crate::utils::FileIdentity,
+  inode_pin: Option<std::fs::File>,
 ) {
-  if identity.matches_path(path) {
-    let _ = std::fs::remove_file(path);
-  }
-  let parent = match path.parent() {
-    Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
-    _ => ::std::path::PathBuf::from("."),
+  // On POSIX, identity-checked unlink without an active pin is
+  // unsafe — between the original handle's close and the identity
+  // probe, the kernel can recycle `(dev, ino)` so a path-reused file
+  // unrelated to ours passes the identity comparison and gets
+  // unlinked. If the caller couldn't dup the fd (EMFILE etc.) and
+  // passed `None`, refuse the unlink and fsync the parent only.
+  #[cfg(unix)]
+  let _inode_pin: std::fs::File = match inode_pin {
+    Some(f) => f,
+    None => {
+      let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => ::std::path::PathBuf::from("."),
+      };
+      let _ = crate::utils::sync_directory(&parent);
+      return;
+    }
   };
-  let _ = crate::utils::sync_directory(&parent);
+  #[cfg(not(unix))]
+  // Windows: file_index/volume_serial isn't recycled the way Unix
+  // (dev, ino) is; no pin is required for path-reuse safety.
+  let _inode_pin = inode_pin;
+  let parent = match crate::utils::open_parent_for_sync(path) {
+    Ok(p) => p,
+    Err(_) => {
+      // Can't even open parent — fall back to fsync-by-path of the
+      // path's parent component. No unlink (we'd be path-based
+      // without the parent_handle that binds the unlink to the same
+      // open directory we identity-probed).
+      let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => ::std::path::PathBuf::from("."),
+      };
+      let _ = crate::utils::sync_directory(&parent);
+      return;
+    }
+  };
+  // Probe identity bound to parent.
+  let probe = match crate::utils::identity_at_or_path(&parent, path) {
+    Ok(p) => p,
+    Err(_) => {
+      // Identity probe failed (path missing, symlink refused, etc.)
+      // Skip the unlink; just sync the parent for any pending state.
+      let _ = crate::utils::sync_parent_handle(&parent);
+      return;
+    }
+  };
+  if !identity.is_known_equal(&probe) {
+    // Path-reuse: leave the path-reused file alone.
+    let _ = crate::utils::sync_parent_handle(&parent);
+    return;
+  }
+  // Unlink bound to the same parent handle (Unix) / same handle as
+  // identity probe (Windows).
+  let _ = crate::utils::unlink_at_or_path(&parent, path, identity);
+  let _ = crate::utils::sync_parent_handle(&parent);
 }
 
 macro_rules! impl_drop {
@@ -196,14 +311,25 @@ macro_rules! impl_drop {
           }
           // Direct `remove_on_drop` path: the Disk inner is still alive,
           // so we can capture identity from `disk.file_identity` (recorded
-          // at construction) and pass it to an identity-checked unlink
-          // that only deletes if the path still names the original inode.
-          if let $inner::Disk(disk) = &self.inner {
-            let identity = disk.file_identity;
-            let path = disk.path.clone();
+          // at construction), pin the inode via the file's fd (POSIX),
+          // and run the same parent-bound unlink sequence as
+          // `initial_remove_durably`.
+          if matches!(&self.inner, $inner::Disk(_)) {
             let empty = <$inner>::Empty(<$empty>::default());
-            drop(mem::replace(&mut self.inner, empty));
-            crate::mmap_file::drop_unlink_with_identity(&path, identity);
+            let inner = mem::replace(&mut self.inner, empty);
+            if let $inner::Disk(disk) = inner {
+              let identity = disk.file_identity;
+              let path = disk.path;
+              drop(disk.mmap);
+              // Take the inode pin via a per-impl-file helper. Sync
+              // owns the std::fs::File directly — moving it costs
+              // nothing and never fails (no fd alloc). Async helpers
+              // extract via `try_into_std` (tokio) or dup (smol). The
+              // helper consumes disk.file, so the pin and the original
+              // handle never coexist as separate fd owners.
+              let pin: Option<std::fs::File> = sync_drop_pin(disk.file);
+              crate::mmap_file::drop_unlink_with_identity(&path, identity, pin);
+            }
           }
         }
       }
@@ -549,7 +675,8 @@ cfg_async! {
           let empty = AsyncMmapFileMutInner::Empty(AsyncEmptyMmapFile::default());
           let inner = mem::replace(&mut self.inner, empty);
           match inner {
-            AsyncMmapFileMutInner::Disk(disk) => {
+            #[allow(unused_mut)] // `mut` only needed on Unix smol-EMFILE recovery
+            AsyncMmapFileMutInner::Disk(mut disk) => {
               // Run the durable unlink at the wrapper layer so we can
               // classify failures correctly (`NeedsUnlink` vs
               // `NeedsParentSync`). Delegating to the disk inner would
@@ -558,9 +685,48 @@ cfg_async! {
               // already been unlinked and possibly reused.
               let path = disk.path.clone();
               let identity = disk.file_identity;
-              drop(disk.mmap);
+              // Take the inode pin via a runtime-specific helper.
+              // tokio's `extract_pin_or_err` uses
+              // `tokio::fs::File::into_std` (no fd alloc — never fails
+              // for fd reasons). smol's helper still needs to dup;
+              // on EMFILE the original file is returned in Err and
+              // we restore self.inner for a clean Err to the caller.
+              //
+              // Deterministic Err semantics: we do NOT set
+              // `remove_on_drop = true` here — that would trigger a
+              // hidden Drop-time dup retry which, if it happens to
+              // succeed, would delete the file *despite* the caller
+              // having seen Err. For retryable delete, callers should
+              // use the wrapper's `remove(&mut self)` API which
+              // preserves `self` for an explicit retry.
+              #[cfg(unix)]
+              let pin: std::fs::File = {
+                let async_file = disk.file;
+                match extract_pin_or_err(async_file).await {
+                  Ok(p) => p,
+                  Err((file_back, e)) => {
+                    // smol EMFILE: clean Err. File remains on disk;
+                    // caller can use std::fs::remove_file or retry
+                    // via remove(&mut self) once fd pressure subsides.
+                    disk.file = file_back;
+                    self.inner = AsyncMmapFileMutInner::Disk(disk);
+                    return Err(e);
+                  }
+                }
+              };
+              #[cfg(not(unix))]
               drop(disk.file);
-              match initial_remove_durably_async(&path, identity).await {
+              // disk.file already moved into the helper on Unix Ok
+              // path; mmap drops cleanly here.
+              drop(disk.mmap);
+              match initial_remove_durably_async(
+                &path,
+                identity,
+                #[cfg(unix)]
+                pin,
+              )
+              .await
+              {
                 Ok(()) => {
                   self.deleted = true;
                   Ok(())
@@ -1908,108 +2074,149 @@ cfg_async! {
 
   macro_rules! delcare_and_impl_async_mmap_file_mut {
     ($filename_prefix: literal, $doc_test_runtime: literal, $path_str: literal) => {
-      async fn sync_parent_path_async(path: &::std::path::Path) -> Result<()> {
-        let parent = match path.parent() {
-          Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
-          _ => ::std::path::PathBuf::from("."),
-        };
-        sync_dir_async(&parent).await
-      }
-
       /// Initial-call durable unlink: see sync sibling
       /// `initial_remove_durably`. Identity-check first, then unlink. The
       /// first unlink runs after the wrapper has dropped its handle, so a
       /// concurrent rename + recreate could already have happened — the
       /// pre-unlink identity check refuses to delete a different file at
       /// the same path.
+      /// `inode_pin` mirrors the sync sibling: a `std::fs::File`
+      /// duplicated from the original async file descriptor (POSIX) so
+      /// the inode it refers to cannot be recycled while the identity
+      /// probe + unlink run. Windows callers pass `None`.
+      ///
+      /// The entire blocking sequence (open parent, fstatat, unlinkat,
+      /// fsync) runs through the runtime's blocking-task pool
+      /// (`tokio::task::spawn_blocking` / `smol::unblock`) so a slow
+      /// filesystem can't stall the async executor.
       async fn initial_remove_durably_async(
         path: &::std::path::Path,
         identity: crate::utils::FileIdentity,
+        #[cfg(unix)] inode_pin: std::fs::File,
       ) -> ::std::result::Result<
         (),
         (crate::mmap_file::PendingDelete, Error),
       > {
-        // Pre-open the parent dir handle (sync — single short syscall;
-        // tokio/smol's async-File would just dispatch to the same blocking
-        // I/O thread pool). This pins the original parent inode so the
-        // post-unlink fsync is durable even if the path's parent is
-        // renamed mid-operation.
-        let parent_handle = match crate::utils::open_parent_for_sync(path) {
-          Ok(h) => h,
-          Err(e) => {
-            return Err((
-              crate::mmap_file::PendingDelete::NeedsUnlink {
-                path: path.to_path_buf(),
-                identity,
-              },
-              e,
-            ));
-          }
-        };
-        // Synchronous metadata is fine here: we just need the identity
-        // tokens, which `std::fs::metadata` returns directly. The async
-        // runtime's `metadata()` would block on a thread pool anyway for
-        // a single fstat-equivalent.
-        match std::fs::metadata(path) {
-          Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {
-            return Err((
-              crate::mmap_file::PendingDelete::NeedsParentSync(path.to_path_buf()),
-              e,
-            ));
-          }
-          Err(e) => {
-            return Err((
-              crate::mmap_file::PendingDelete::NeedsUnlink {
-                path: path.to_path_buf(),
-                identity,
-              },
-              e,
-            ));
-          }
-          Ok(probe) => {
-            let probe_id = crate::utils::FileIdentity::from_metadata(&probe);
-            if !identity.is_known_equal(&probe_id) {
-              let err = Error::other(format!(
-                "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink, or platform identity unavailable)",
-                path.display(),
-              ));
+        // pin is required (not Option) on POSIX. Callers must dup
+        // before calling and hard-fail on dup failure. The pin is
+        // moved into `PendingDelete::NeedsUnlink` on retryable
+        // failures so retries inherit it; otherwise dropped when the
+        // closure exits.
+        let path = path.to_path_buf();
+        run_blocking_io(move || -> ::std::result::Result<(), (crate::mmap_file::PendingDelete, Error)> {
+          #[cfg(unix)]
+          let inode_pin = inode_pin;
+          let parent_handle = match crate::utils::open_parent_for_sync(&path) {
+            Ok(h) => h,
+            Err(e) => {
               return Err((
                 crate::mmap_file::PendingDelete::NeedsUnlink {
-                  path: path.to_path_buf(),
+                  path: path.clone(),
                   identity,
+                  #[cfg(unix)]
+                  pin: inode_pin,
                 },
-                err,
+                e,
               ));
             }
+          };
+          match crate::utils::identity_at_or_path(&parent_handle, &path) {
+            Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {
+              // See sync `initial_remove_durably` for the rationale.
+              // NotFound never proves crash-durable deletion
+              // (rename-then-unlink-elsewhere produces nlink==0 too,
+              // but the entry was removed from a parent we don't
+              // fsync). Always NeedsUnlink.
+              return Err((
+                crate::mmap_file::PendingDelete::NeedsUnlink {
+                  path: path.clone(),
+                  identity,
+                  #[cfg(unix)]
+                  pin: inode_pin,
+                },
+                e,
+              ));
+            }
+            Err(e) => {
+              return Err((
+                crate::mmap_file::PendingDelete::NeedsUnlink {
+                  path: path.clone(),
+                  identity,
+                  #[cfg(unix)]
+                  pin: inode_pin,
+                },
+                e,
+              ));
+            }
+            Ok(probe_id) => {
+              if !identity.is_known_equal(&probe_id) {
+                let err = Error::other(format!(
+                  "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink)",
+                  path.display(),
+                ));
+                return Err((
+                  crate::mmap_file::PendingDelete::NeedsUnlink {
+                    path: path.clone(),
+                    identity,
+                    #[cfg(unix)]
+                    pin: inode_pin,
+                  },
+                  err,
+                ));
+              }
+            }
           }
-        }
-        match remove_file(path).await {
-          Ok(()) => match crate::utils::sync_parent_handle(&parent_handle) {
-            Ok(()) => Ok(()),
+          match crate::utils::unlink_at_or_path(&parent_handle, &path, identity) {
+            Ok(()) => match crate::utils::sync_parent_handle(&parent_handle) {
+              Ok(()) => Ok(()),
+              Err(e) => Err((
+                crate::mmap_file::PendingDelete::NeedsParentSync {
+                  path: path.clone(),
+                  parent_handle,
+                },
+                e,
+              )),
+            },
+            Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {
+              // NotFound from `unlinkat` after a matching probe could
+              // still be a rename-then-unlink-elsewhere. We can't
+              // claim our parent fsync makes anything crash-durable.
+              // Stay NeedsUnlink.
+              Err((
+                crate::mmap_file::PendingDelete::NeedsUnlink {
+                  path: path.clone(),
+                  identity,
+                  #[cfg(unix)]
+                  pin: inode_pin,
+                },
+                e,
+              ))
+            }
             Err(e) => Err((
-              crate::mmap_file::PendingDelete::NeedsParentSync(path.to_path_buf()),
+              crate::mmap_file::PendingDelete::NeedsUnlink {
+                path: path.clone(),
+                identity,
+                #[cfg(unix)]
+                pin: inode_pin,
+              },
               e,
             )),
-          },
-          Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => Err((
-            crate::mmap_file::PendingDelete::NeedsParentSync(path.to_path_buf()),
-            e,
-          )),
-          Err(e) => Err((
-            crate::mmap_file::PendingDelete::NeedsUnlink {
-              path: path.to_path_buf(),
-              identity,
-            },
-            e,
-          )),
-        }
+          }
+        })
+        .await
       }
 
-      /// Retry a pending delete in a path-reuse-safe way. `NeedsUnlink`
-      /// re-checks the captured identity against the path before
-      /// unlinking; if the identity no longer matches (path was reused),
-      /// we keep state and return a tagged error rather than deleting an
-      /// unrelated file.
+      /// Retry a pending delete in a path-reuse-safe way.
+      ///
+      /// `NeedsParentSync` only fsyncs the parent — never re-calls
+      /// `remove_file`. `NeedsUnlink` delegates to
+      /// `initial_remove_durably_async` so the nlink classification
+      /// (nlink==0 → NeedsParentSync, nlink>0 → NeedsUnlink) and
+      /// NotFound handling apply uniformly to both initial and retry
+      /// paths. Previously this branch open-coded a probe-then-unlink
+      /// that converted every probe error into a path-reuse refusal,
+      /// missing the "renamed away then unlinked at the new name"
+      /// case (pin nlink==0 → should converge to NeedsParentSync).
       async fn retry_pending_delete_async(
         pending: crate::mmap_file::PendingDelete,
       ) -> ::std::result::Result<
@@ -2017,55 +2224,37 @@ cfg_async! {
         (crate::mmap_file::PendingDelete, Error),
       > {
         match pending {
-          crate::mmap_file::PendingDelete::NeedsParentSync(path) => {
-            match sync_parent_path_async(&path).await {
-              Ok(()) => Ok(()),
-              Err(e) => Err((crate::mmap_file::PendingDelete::NeedsParentSync(path), e)),
-            }
-          }
-          crate::mmap_file::PendingDelete::NeedsUnlink { path, identity } => {
-            if !identity.matches_path(&path) {
-              let err = Error::other(format!(
-                "cannot retry remove on '{}': path no longer names the original file (path-reuse detected); the file you originally intended to delete is presumed gone or moved",
-                path.display(),
-              ));
-              return Err((
-                crate::mmap_file::PendingDelete::NeedsUnlink { path, identity },
-                err,
-              ));
-            }
-            // Pre-open parent dir handle for the original-inode fsync.
-            let parent_handle = match crate::utils::open_parent_for_sync(&path) {
-              Ok(h) => h,
-              Err(e) => {
-                return Err((
-                  crate::mmap_file::PendingDelete::NeedsUnlink { path, identity },
-                  e,
-                ));
-              }
-            };
-            match remove_file(&path).await {
-              Ok(()) => match crate::utils::sync_parent_handle(&parent_handle) {
+          crate::mmap_file::PendingDelete::NeedsParentSync {
+            path,
+            parent_handle,
+          } => {
+            run_blocking_io(move || -> ::std::result::Result<(), (crate::mmap_file::PendingDelete, Error)> {
+              match crate::utils::sync_parent_handle(&parent_handle) {
                 Ok(()) => Ok(()),
                 Err(e) => Err((
-                  crate::mmap_file::PendingDelete::NeedsParentSync(path),
+                  crate::mmap_file::PendingDelete::NeedsParentSync {
+                    path,
+                    parent_handle,
+                  },
                   e,
                 )),
-              },
-              Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {
-                match crate::utils::sync_parent_handle(&parent_handle) {
-                  Ok(()) => Ok(()),
-                  Err(e2) => Err((
-                    crate::mmap_file::PendingDelete::NeedsParentSync(path),
-                    e2,
-                  )),
-                }
               }
-              Err(e) => Err((
-                crate::mmap_file::PendingDelete::NeedsUnlink { path, identity },
-                e,
-              )),
-            }
+            })
+            .await
+          }
+          crate::mmap_file::PendingDelete::NeedsUnlink {
+            path,
+            identity,
+            #[cfg(unix)]
+            pin,
+          } => {
+            initial_remove_durably_async(
+              &path,
+              identity,
+              #[cfg(unix)]
+              pin,
+            )
+            .await
           }
         }
       }
@@ -2663,20 +2852,24 @@ cfg_async! {
         /// If invoke [`AsyncMmapFileMut::freeze`], then the file will
         /// not be removed even though the field `remove_on_drop` is true.
         ///
-        /// # Path-reuse safety: this is best-effort, not guaranteed
+        /// # Path-reuse safety
         ///
-        /// As of v0.5.0 the auto-cleanup path no longer calls `remove_file`
-        /// from `Drop`. By the time `Drop` runs, the original `File` handle
-        /// has been moved out of the wrapper, so there is no way to verify
-        /// that the path still names the file you originally opened — and
-        /// blind path-based unlink could delete an unrelated file another
-        /// actor created at the same path. `Drop` only fsyncs the parent
-        /// directory now.
+        /// `Drop` runs the same identity-checked, parent-bound unlink
+        /// sequence as the explicit `remove()` / `drop_remove()` paths
+        /// (POSIX: `fstatat` + `unlinkat` against a pre-opened parent
+        /// dir fd, with the original async file's fd duped and held
+        /// alive across the probe + unlink so the `(dev, ino)` we
+        /// compare to can't be recycled). If the path no longer names
+        /// the original inode — or if it became a symlink — `Drop`
+        /// leaves it alone. The residual risks are the irreducible
+        /// probe→unlink TOCTOU window and Windows' lack of true
+        /// openat-equivalents; see `FileIdentity` for the full
+        /// residual-race breakdown.
         ///
-        /// If you require deterministic, identity-checked cleanup, call
-        /// [`AsyncMmapFileMut::remove`] or [`AsyncMmapFileMut::drop_remove`]
-        /// explicitly before the wrapper is dropped — those run while a
-        /// fresh `File` handle is still in scope and can verify identity.
+        /// If you require synchronous error reporting, call
+        /// [`AsyncMmapFileMut::remove`] or
+        /// [`AsyncMmapFileMut::drop_remove`] explicitly — `Drop`
+        /// swallows errors because it cannot return a `Result`.
         ///
         /// [`AsyncMmapFileMut::freeze`]: structs.AsyncMmapFileMut.html#methods.freeze
         /// [`AsyncMmapFileMut::remove`]: structs.AsyncMmapFileMut.html#methods.remove
@@ -2740,12 +2933,38 @@ cfg_async! {
           let empty = AsyncMmapFileMutInner::Empty(AsyncEmptyMmapFile::default());
           let inner = mem::replace(&mut self.inner, empty);
           match inner {
-            AsyncMmapFileMutInner::Disk(disk) => {
-              let path = disk.path;
+            #[allow(unused_mut)] // `mut` only needed on Unix smol-EMFILE recovery
+            AsyncMmapFileMutInner::Disk(mut disk) => {
+              let path = disk.path.clone();
               let identity = disk.file_identity;
-              drop(disk.mmap);
+              // Same runtime-specific helper as drop_remove. tokio
+              // uses `into_std` (no fd alloc); smol falls back to dup
+              // and on EMFILE returns the file so we can restore
+              // self.inner — `remove(&mut self)` itself preserves self
+              // for the caller to retry.
+              #[cfg(unix)]
+              let pin: std::fs::File = {
+                let async_file = disk.file;
+                match extract_pin_or_err(async_file).await {
+                  Ok(p) => p,
+                  Err((file_back, e)) => {
+                    disk.file = file_back;
+                    self.inner = AsyncMmapFileMutInner::Disk(disk);
+                    return Err(e);
+                  }
+                }
+              };
+              #[cfg(not(unix))]
               drop(disk.file);
-              match initial_remove_durably_async(&path, identity).await {
+              drop(disk.mmap);
+              match initial_remove_durably_async(
+                &path,
+                identity,
+                #[cfg(unix)]
+                pin,
+              )
+              .await
+              {
                 Ok(()) => {
                   self.deleted = true;
                   Ok(())

--- a/fmmap/src/mmap_file/smol_impl.rs
+++ b/fmmap/src/mmap_file/smol_impl.rs
@@ -13,10 +13,64 @@ use crate::{
   smol::{AsyncMmapFileReader, AsyncMmapFileWriter, AsyncOptions},
   utils::smol::sync_dir_async,
 };
-use smol::{
-  fs::remove_file,
-  io::{AsyncWriteExt, Cursor},
-};
+use smol::io::{AsyncWriteExt, Cursor};
+
+/// Run a blocking IO closure off the smol executor (`smol::unblock`).
+/// Used by the durable-delete path so `unlinkat` + `fsync` don't stall
+/// the executor.
+async fn run_blocking_io<F, T>(f: F) -> T
+where
+  F: FnOnce() -> T + Send + 'static,
+  T: Send + 'static,
+{
+  smol::unblock(f).await
+}
+
+/// Extract the inode pin used by the durable-delete path from an
+/// async file. See `mmap_file::tokio_impl::extract_pin_or_err`.
+///
+/// smol: `async-fs::File` exposes no `into_std` equivalent (its inner
+/// `std::fs::File` is held by an `Arc<File>` shared with a background
+/// `Unblock` task). Falls back to `fcntl_dupfd_cloexec`. On EMFILE
+/// the original file is returned in `Err((file, e))` so the caller
+/// can restore `self.inner` and let the `remove_on_drop` fallback
+/// retry via Drop.
+#[cfg(unix)]
+async fn extract_pin_or_err(
+  file: ::smol::fs::File,
+) -> std::result::Result<std::fs::File, (::smol::fs::File, Error)> {
+  use std::os::fd::{AsRawFd, BorrowedFd};
+  let raw = file.as_raw_fd();
+  // SAFETY: file is alive for the duration of this borrow.
+  let borrowed = unsafe { BorrowedFd::borrow_raw(raw) };
+  match rustix::io::fcntl_dupfd_cloexec(borrowed, 0) {
+    Ok(owned) => {
+      drop(file);
+      Ok(std::fs::File::from(owned))
+    }
+    Err(e) => Err((file, std::io::Error::from(e))),
+  }
+}
+
+/// Synchronous variant for `impl_drop!`'s `remove_on_drop` path.
+/// async-fs has no into_std equivalent and Drop can't await, so we
+/// still dup. EMFILE leaves the file undeleted (Drop is best-effort);
+/// same documented limitation as the smol raw async drop_remove.
+#[cfg(unix)]
+fn sync_drop_pin(file: ::smol::fs::File) -> Option<std::fs::File> {
+  use std::os::fd::{AsRawFd, BorrowedFd};
+  let raw = file.as_raw_fd();
+  // SAFETY: file is alive for the duration of the borrow.
+  let borrowed = unsafe { BorrowedFd::borrow_raw(raw) };
+  rustix::io::fcntl_dupfd_cloexec(borrowed, 0)
+    .ok()
+    .map(std::fs::File::from)
+}
+#[cfg(not(unix))]
+fn sync_drop_pin(file: ::smol::fs::File) -> Option<std::fs::File> {
+  drop(file);
+  None
+}
 
 declare_async_mmap_file_ext!(
   AsyncDiskMmapFileMut,

--- a/fmmap/src/mmap_file/sync_impl.rs
+++ b/fmmap/src/mmap_file/sync_impl.rs
@@ -25,30 +25,45 @@ fn sync_new_file_parent(path: &Path) -> Result<()> {
   crate::utils::sync_dir(&parent)
 }
 
-/// Initial-call durable unlink: identity-check, then `remove_file`, then
-/// parent fsync. `identity` was captured at file open; we use it here
-/// (and on every retry) to confirm the path still names the original
-/// inode before unlinking. Even the *first* unlink runs after the
-/// caller has dropped the original mapping/file, so a concurrent
-/// rename-and-recreate can already have happened by the time we get
-/// here — the pre-unlink identity check closes that window.
+/// Initial-call durable unlink with optional inode pin.
 ///
-/// Identity check distinguishes three cases:
-/// - path metadata `NotFound` → original inode is presumed already gone,
-///   treat the same as `NotFound` from `remove_file` (NeedsParentSync,
-///   surface the NotFound error to the caller).
-/// - metadata succeeds but identity mismatches → another file took the
-///   path (path-reuse). Refuse the unlink, keep `NeedsUnlink` state.
-/// - identity matches → proceed with `remove_file`.
+/// Sequence: open parent dir handle → probe identity at the path
+/// (`fstatat` on POSIX, bound to the same parent fd) → unlink at the
+/// path (`unlinkat` on POSIX, bound to the same parent fd) → fsync the
+/// parent handle. All four ops are bound to the same parent inode on
+/// POSIX, so a parent rename mid-operation can't direct durability to
+/// the wrong directory.
+///
+/// `inode_pin` is the original `File` handle, held alive across probe +
+/// unlink so the kernel cannot recycle the inode number while the
+/// identity check runs. Required on POSIX where `(dev, ino)` is the
+/// identity — without the pin, a concurrent replacement created right
+/// after the caller closed the file could land on the same inode and
+/// pass `is_known_equal`. On Windows, holding the handle without
+/// `FILE_SHARE_DELETE` would *prevent* unlink, so the caller must drop
+/// it before calling and pass `None`. The pin is dropped on function
+/// exit, after the unlink.
+///
+/// Identity check distinguishes three cases: `NotFound` (original inode
+/// presumed already gone, surface as `NeedsParentSync`); identity
+/// mismatch (path was reused, refuse unlink, keep `NeedsUnlink`);
+/// identity match (proceed with `unlinkat`).
 fn initial_remove_durably(
   path: &Path,
   identity: crate::utils::FileIdentity,
+  #[cfg(unix)] inode_pin: std::fs::File,
 ) -> std::result::Result<(), (crate::mmap_file::PendingDelete, Error)> {
+  // pin is a required parameter on POSIX (not Option). Callers must
+  // dup before calling and hard-fail on dup failure, so this function
+  // never sees a missing pin. The pin is moved into
+  // `PendingDelete::NeedsUnlink` on retryable failures so subsequent
+  // retries inherit it; otherwise dropped on function exit.
   // Pin a handle to the *original* parent inode BEFORE the unlink. If
   // the path's parent gets renamed/replaced between unlink and fsync, a
   // path-based fsync would commit metadata on the wrong inode; the
   // pre-opened handle commits to the inode that actually contained our
-  // directory entry.
+  // directory entry. The handle is also stashed in any `NeedsParentSync`
+  // pending state so retry fsyncs the same inode.
   let parent_handle = match crate::utils::open_parent_for_sync(path) {
     Ok(h) => h,
     Err(e) => {
@@ -56,15 +71,37 @@ fn initial_remove_durably(
         crate::mmap_file::PendingDelete::NeedsUnlink {
           path: path.to_path_buf(),
           identity,
+          #[cfg(unix)]
+          pin: inode_pin,
         },
         e,
       ));
     }
   };
-  match std::fs::metadata(path) {
+  // Probe identity *relative to* parent_handle on POSIX (fstatat) so
+  // the probe is bound to the same inode the unlink will go through —
+  // a path-based probe could race a parent rename between
+  // open_parent_for_sync and probe.
+  match crate::utils::identity_at_or_path(&parent_handle, path) {
     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+      // NotFound never proves crash-durable deletion. An nlink-based
+      // "durably gone" inference would be wrong because an external
+      // rename + unlink-elsewhere also produces `nlink == 0` while
+      // leaving the actual unlink in a parent we don't fsync —
+      // fsyncing OUR parent then doesn't make their unlink
+      // crash-durable. Always route NotFound to NeedsUnlink so retry
+      // surfaces NotFound rather than false-success-via-fsync.
+      // Drop's NeedsUnlink path still best-effort fsyncs the parent,
+      // which IS correct in the common "external rm in our parent"
+      // case — we just don't promise the caller that deletion
+      // succeeded.
       return Err((
-        crate::mmap_file::PendingDelete::NeedsParentSync(path.to_path_buf()),
+        crate::mmap_file::PendingDelete::NeedsUnlink {
+          path: path.to_path_buf(),
+          identity,
+          #[cfg(unix)]
+          pin: inode_pin,
+        },
         e,
       ));
     }
@@ -73,43 +110,67 @@ fn initial_remove_durably(
         crate::mmap_file::PendingDelete::NeedsUnlink {
           path: path.to_path_buf(),
           identity,
+          #[cfg(unix)]
+          pin: inode_pin,
         },
         e,
       ));
     }
-    Ok(probe) => {
-      let probe_id = crate::utils::FileIdentity::from_metadata(&probe);
+    Ok(probe_id) => {
       if !identity.is_known_equal(&probe_id) {
         let err = Error::other(format!(
-          "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink, or platform identity unavailable)",
+          "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink)",
           path.display(),
         ));
         return Err((
           crate::mmap_file::PendingDelete::NeedsUnlink {
             path: path.to_path_buf(),
             identity,
+            #[cfg(unix)]
+            pin: inode_pin,
           },
           err,
         ));
       }
     }
   }
-  match std::fs::remove_file(path) {
+  // Bind the unlink to parent_handle (POSIX `unlinkat`) so the
+  // subsequent `sync_parent_handle` is durable for the directory the
+  // entry was actually removed from. There's still an irreducible
+  // narrow TOCTOU between the identity probe and the unlinkat call,
+  // but the *broad* race against parent renames is now closed.
+  match crate::utils::unlink_at_or_path(&parent_handle, path, identity) {
     Ok(()) => match crate::utils::sync_parent_handle(&parent_handle) {
       Ok(()) => Ok(()),
       Err(e) => Err((
-        crate::mmap_file::PendingDelete::NeedsParentSync(path.to_path_buf()),
+        crate::mmap_file::PendingDelete::NeedsParentSync {
+          path: path.to_path_buf(),
+          parent_handle,
+        },
         e,
       )),
     },
-    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err((
-      crate::mmap_file::PendingDelete::NeedsParentSync(path.to_path_buf()),
-      e,
-    )),
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+      // Same as pre-probe NotFound — never claim durable deletion.
+      // Post-probe NotFound from `unlinkat` could be a
+      // rename-then-unlink-elsewhere; our parent fsync wouldn't
+      // commit the right journal. Stay NeedsUnlink.
+      Err((
+        crate::mmap_file::PendingDelete::NeedsUnlink {
+          path: path.to_path_buf(),
+          identity,
+          #[cfg(unix)]
+          pin: inode_pin,
+        },
+        e,
+      ))
+    }
     Err(e) => Err((
       crate::mmap_file::PendingDelete::NeedsUnlink {
         path: path.to_path_buf(),
         identity,
+        #[cfg(unix)]
+        pin: inode_pin,
       },
       e,
     )),
@@ -128,57 +189,36 @@ fn retry_pending_delete(
   pending: crate::mmap_file::PendingDelete,
 ) -> std::result::Result<(), (crate::mmap_file::PendingDelete, Error)> {
   match pending {
-    crate::mmap_file::PendingDelete::NeedsParentSync(path) => match sync_parent_path(&path) {
+    crate::mmap_file::PendingDelete::NeedsParentSync {
+      path,
+      parent_handle,
+    } => match crate::utils::sync_parent_handle(&parent_handle) {
       Ok(()) => Ok(()),
-      Err(e) => Err((crate::mmap_file::PendingDelete::NeedsParentSync(path), e)),
-    },
-    crate::mmap_file::PendingDelete::NeedsUnlink { path, identity } => {
-      if !identity.matches_path(&path) {
-        let err = Error::other(format!(
-          "cannot retry remove on '{}': path no longer names the original file (path-reuse detected); the file you originally intended to delete is presumed gone or moved",
-          path.display(),
-        ));
-        return Err((
-          crate::mmap_file::PendingDelete::NeedsUnlink { path, identity },
-          err,
-        ));
-      }
-      // Same parent-handle-before-unlink pattern as initial_remove_durably.
-      let parent_handle = match crate::utils::open_parent_for_sync(&path) {
-        Ok(h) => h,
-        Err(e) => {
-          return Err((
-            crate::mmap_file::PendingDelete::NeedsUnlink { path, identity },
-            e,
-          ));
-        }
-      };
-      match std::fs::remove_file(&path) {
-        Ok(()) => match crate::utils::sync_parent_handle(&parent_handle) {
-          Ok(()) => Ok(()),
-          Err(e) => Err((crate::mmap_file::PendingDelete::NeedsParentSync(path), e)),
+      Err(e) => Err((
+        crate::mmap_file::PendingDelete::NeedsParentSync {
+          path,
+          parent_handle,
         },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-          match crate::utils::sync_parent_handle(&parent_handle) {
-            Ok(()) => Ok(()),
-            Err(e2) => Err((crate::mmap_file::PendingDelete::NeedsParentSync(path), e2)),
-          }
-        }
-        Err(e) => Err((
-          crate::mmap_file::PendingDelete::NeedsUnlink { path, identity },
-          e,
-        )),
-      }
+        e,
+      )),
+    },
+    crate::mmap_file::PendingDelete::NeedsUnlink {
+      path,
+      identity,
+      #[cfg(unix)]
+      pin,
+    } => {
+      // Just delegate to `initial_remove_durably`. It will re-stitch
+      // the pin into `NeedsUnlink` on Err so the next retry inherits
+      // a still-active inode pin.
+      initial_remove_durably(
+        &path,
+        identity,
+        #[cfg(unix)]
+        pin,
+      )
     }
   }
-}
-
-fn sync_parent_path(path: &Path) -> Result<()> {
-  let parent = match path.parent() {
-    Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
-    _ => std::path::PathBuf::from("."),
-  };
-  crate::utils::sync_dir(&parent)
 }
 
 /// Utility methods to [`MmapFile`]
@@ -1175,8 +1215,22 @@ impl MmapFileMutExt for MmapFileMut {
         let path = disk.path.clone();
         let identity = disk.file_identity;
         drop(disk.mmap);
+        // Keep `disk.file` alive across the probe+unlink on POSIX so
+        // the inode it refers to cannot be recycled (which would let
+        // a fresh file at the same path pass identity). Windows:
+        // holding the file without FILE_SHARE_DELETE would prevent
+        // the unlink itself, so we drop it first and rely on
+        // `(volume_serial, file_index)` not being recycled.
+        #[cfg(unix)]
+        let pin: std::fs::File = disk.file;
+        #[cfg(not(unix))]
         drop(disk.file);
-        match initial_remove_durably(&path, identity) {
+        match initial_remove_durably(
+          &path,
+          identity,
+          #[cfg(unix)]
+          pin,
+        ) {
           Ok(()) => {
             self.deleted = true;
             Ok(())
@@ -1797,19 +1851,23 @@ impl MmapFileMut {
   /// If invoke [`MmapFileMut::freeze`], then the file will
   /// not be removed even though the field `remove_on_drop` is true.
   ///
-  /// # Path-reuse safety: this is best-effort, not guaranteed
+  /// # Path-reuse safety
   ///
-  /// As of v0.5.0 the auto-cleanup path no longer calls `remove_file` from
-  /// `Drop`. By the time `Drop` runs, the original `File` handle has been
-  /// moved out of the wrapper, so there is no way to verify that the path
-  /// still names the file you originally opened — and blind path-based
-  /// unlink could silently delete an unrelated file another actor created
-  /// at the same path. `Drop` now only fsyncs the parent directory.
+  /// `Drop` runs the same identity-checked, parent-bound unlink
+  /// sequence as the explicit `remove()` / `drop_remove()` paths
+  /// (POSIX: `fstatat` + `unlinkat` against a pre-opened parent dir
+  /// fd, with the original file's fd duped and held alive across the
+  /// probe + unlink so the `(dev, ino)` we compare to can't be
+  /// recycled). If the path no longer names the original inode — or
+  /// if it became a symlink — `Drop` leaves it alone. The residual
+  /// risks are the irreducible probe→unlink TOCTOU window (one
+  /// syscall) and Windows' lack of true openat-equivalents; see
+  /// `FileIdentity` for the full residual-race breakdown.
   ///
-  /// If you require deterministic, identity-checked cleanup, call
-  /// [`MmapFileMut::remove`] or [`MmapFileMut::drop_remove`] explicitly
-  /// before the wrapper is dropped — those run while a fresh `File`
-  /// handle is still in scope and can verify identity.
+  /// If you require synchronous error reporting, call
+  /// [`MmapFileMut::remove`] or [`MmapFileMut::drop_remove`]
+  /// explicitly before the wrapper is dropped — `Drop` swallows
+  /// errors because it cannot return a `Result`.
   ///
   /// [`MmapFileMut::freeze`]: structs.MmapFileMut.html#methods.freeze
   /// [`MmapFileMut::remove`]: structs.MmapFileMut.html#methods.remove
@@ -1885,18 +1943,24 @@ impl MmapFileMut {
       MmapFileMutInner::Disk(disk) => {
         let path = disk.path;
         let identity = disk.file_identity;
-        // On Windows we must close the handle before removing; on Unix
-        // unlink succeeds while the inode is still mapped, but for symmetry
-        // we drop first either way so the behavior is identical across
-        // platforms.
         drop(disk.mmap);
+        // Keep the inode pinned through probe+unlink on POSIX.
+        // Windows must drop first (see drop_remove sibling).
+        #[cfg(unix)]
+        let pin: std::fs::File = disk.file;
+        #[cfg(not(unix))]
         drop(disk.file);
         // Initial call: a missing file is the user's error. On other
         // failures we record `PendingDelete::NeedsUnlink`; if `remove_file`
         // itself succeeded but parent fsync didn't, we record
         // `NeedsParentSync` so retry doesn't re-call `remove_file` on a
         // possibly-reused path.
-        match initial_remove_durably(&path, identity) {
+        match initial_remove_durably(
+          &path,
+          identity,
+          #[cfg(unix)]
+          pin,
+        ) {
           Ok(()) => {
             self.deleted = true;
             Ok(())
@@ -1925,12 +1989,43 @@ impl_drop!(MmapFileMut, MmapFileMutInner, EmptyMmapFile);
 
 impl_sync_tests!("", MmapFile, MmapFileMut);
 
+/// Extract the inode pin from a sync `std::fs::File` owned at Drop
+/// time. Sync owns the file directly — just move it in. No fd
+/// allocation, no EMFILE failure mode. Called by `impl_drop!`'s
+/// `remove_on_drop` path; the macro's name resolution finds this
+/// per-impl-file (sync here, async in `mmap_file/{tokio,smol}_impl.rs`).
+#[cfg(unix)]
+fn sync_drop_pin(file: std::fs::File) -> Option<std::fs::File> {
+  Some(file)
+}
+#[cfg(not(unix))]
+fn sync_drop_pin(file: std::fs::File) -> Option<std::fs::File> {
+  drop(file);
+  None
+}
+
 #[cfg(test)]
 mod regression {
   use super::*;
   use crate::Options;
   use scopeguard::defer;
   use std::io::Write;
+
+  /// Test helper: dup a `File`'s descriptor via `F_DUPFD_CLOEXEC` and
+  /// wrap the new descriptor as an owned `File`. Mirrors the production
+  /// dup that wrappers do before calling `initial_remove_durably`. Used
+  /// to populate `PendingDelete::NeedsUnlink::pin` in tests that
+  /// construct the pending state directly.
+  #[cfg(unix)]
+  fn dup_for_pin(file: &std::fs::File) -> std::fs::File {
+    use std::os::fd::{AsRawFd, BorrowedFd};
+    let raw = file.as_raw_fd();
+    // SAFETY: `file` is a live, owned File; the borrow lives for the
+    // call and `fcntl_dupfd_cloexec` returns a fresh OwnedFd.
+    let borrowed = unsafe { BorrowedFd::borrow_raw(raw) };
+    let owned = rustix::io::fcntl_dupfd_cloexec(borrowed, 0).expect("fcntl dup");
+    std::fs::File::from(owned)
+  }
 
   /// Finding #1: even though the public `lock_shared` is `unsafe`, calling it
   /// on a writable mapping does in fact downgrade the auto-acquired exclusive
@@ -1988,9 +2083,9 @@ mod regression {
     assert_eq!(bytes, b"keep me");
   }
 
-  /// Codex review #3: a `truncate` failure that happens BEFORE the disk
-  /// backend swaps in the anonymous placeholder (e.g. the cow-unsupported
-  /// check) must NOT detach the live mapping. The original mapping should
+  /// A `truncate` failure that happens BEFORE the disk backend swaps
+  /// in the anonymous placeholder (e.g. the cow-unsupported check)
+  /// must NOT detach the live mapping. The original mapping should
   /// stay usable so the caller can flush/read it.
   #[test]
   fn pre_swap_truncate_failure_preserves_mapping() {
@@ -2023,9 +2118,10 @@ mod regression {
     assert_eq!(&cow.as_slice()[..b"modified".len()], b"modified");
   }
 
-  /// Codex finding #2 (truncate clamp): opening with a large `len` and then
-  /// truncating to a smaller size must NOT leave a mapping that extends past
-  /// EOF. The crate clamps the stored `len` to `(new_size - offset)` on remap.
+  /// Truncate clamp: opening with a large `len` and then truncating
+  /// to a smaller size must NOT leave a mapping that extends past
+  /// EOF. The crate clamps the stored `len` to `(new_size - offset)`
+  /// on remap.
   #[test]
   fn truncate_clamps_oversized_len() {
     let path = "_regression_truncate_clamps_len.txt";
@@ -2053,9 +2149,9 @@ mod regression {
     file.flush().unwrap();
   }
 
-  /// Codex finding #2 (offset past EOF): truncating to below the mapping's
-  /// offset must fail with InvalidInput rather than producing a broken
-  /// mapping. The object remains usable (not poisoned) since we check before
+  /// Offset past EOF: truncating to below the mapping's offset must
+  /// fail with InvalidInput rather than producing a broken mapping.
+  /// The object remains usable (not poisoned) since we check before
   /// touching the mapping.
   #[test]
   fn truncate_below_offset_errors() {
@@ -2084,9 +2180,9 @@ mod regression {
     file.flush().unwrap();
   }
 
-  /// Codex finding: `create_with_options` used to drop the user-set
-  /// `Options::mode` / `custom_flags` because `create_in` opened with the
-  /// hard-coded `create_file()` helper instead of routing through
+  /// `create_with_options` used to drop the user-set
+  /// `Options::mode` / `custom_flags` because `create_in` opened with
+  /// the hard-coded `create_file()` helper instead of routing through
   /// `opts.file_opts`. Verify on Unix that a custom mode is honored.
   #[cfg(unix)]
   #[test]
@@ -2105,13 +2201,17 @@ mod regression {
     assert_eq!(mode, 0o600);
   }
 
-  /// Codex finding: `remove()` swaps the inner to Empty before calling
-  /// `remove_file`. If the unlink fails, the original `MmapFileMut` is
-  /// left with an Empty inner whose path is `""`, so a subsequent `Drop`
-  /// can no longer attempt the unlink and the file leaks. Verify the
-  /// wrapper retains the original path on failure (in `pending_drop_remove`
-  /// because deletion was explicitly requested) so Drop has a chance to
-  /// retry regardless of `remove_on_drop`.
+  /// `remove()` swaps the inner to Empty before calling `remove_file`.
+  /// If the unlink fails, the original `MmapFileMut` is left with an
+  /// Empty inner whose path is `""`, so a subsequent `Drop` can no
+  /// longer attempt the unlink and the file leaks. Verify the
+  /// wrapper retains the original path on failure (in
+  /// `pending_drop_remove` because deletion was explicitly requested)
+  /// so Drop has a chance to retry regardless of `remove_on_drop`.
+  ///
+  /// Unix-only: setup uses `std::fs::remove_file` which would fail
+  /// against a still-open handle on Windows.
+  #[cfg(unix)]
   #[test]
   fn remove_failure_retains_path_for_drop_retry() {
     let path = crate::tests::get_random_filename();
@@ -2126,19 +2226,32 @@ mod regression {
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     let pending = f.pending_drop_remove.as_ref().expect("pending state set");
     assert_eq!(pending.path(), path.as_path());
-    // NotFound on initial call → NeedsParentSync (path-reuse safe — retry
-    // must NOT call remove_file again).
+    // NotFound always routes to NeedsUnlink. An nlink-based
+    // NeedsParentSync routing would assume the entry was unlinked
+    // from OUR parent, but a rename + unlink-elsewhere also produces
+    // nlink==0 — fsyncing our parent then doesn't make the other
+    // directory's unlink crash-durable. Surfacing NeedsUnlink is
+    // conservative: caller knows we did not confirm crash-durable
+    // deletion.
     assert!(matches!(
       pending,
-      crate::mmap_file::PendingDelete::NeedsParentSync(_)
+      crate::mmap_file::PendingDelete::NeedsUnlink { .. }
     ));
   }
 
-  /// Codex finding (round 4, medium): a subsequent `remove()` after a
-  /// failed one used to short-circuit on the `_ => Ok(())` arm because the
-  /// inner was Empty, reporting a successful cleanup while the original
-  /// file still existed. Verify the retry actually attempts the unlink
+  /// A subsequent `remove()` after a failed one used to
+  /// short-circuit on the `_ => Ok(())` arm because the inner was
+  /// Empty, reporting a successful cleanup while the original file
+  /// still existed. Verify the retry actually attempts cleanup
   /// against the saved `pending_drop_remove`.
+  ///
+  /// NotFound at probe time stays NeedsUnlink. The retry re-probes;
+  /// against a path-reused (recreated) file the identity check fails
+  /// and we surface a path-reuse error. The recreated file is
+  /// preserved.
+  ///
+  /// Unix-only: see sibling test for rationale.
+  #[cfg(unix)]
   #[test]
   fn remove_retry_attempts_pending_path() {
     let path = crate::tests::get_random_filename();
@@ -2146,39 +2259,47 @@ mod regression {
     let mut f = unsafe { MmapFileMut::create(&path) }.unwrap();
     f.truncate(8).unwrap();
 
-    // First call: pre-delete the file so remove() fails with NotFound;
-    // pending state is `NeedsParentSync` (the inode is gone, only the
-    // parent fsync remains).
+    // First call: pre-delete the file so remove() fails with NotFound.
+    // Pending state is NeedsUnlink — we never confirmed the unlink
+    // happened in OUR parent, so we can't claim crash-durable
+    // deletion via parent fsync alone.
     drop(std::fs::remove_file(&path));
     assert!(f.remove().is_err());
     assert!(matches!(
       f.pending_drop_remove,
-      Some(crate::mmap_file::PendingDelete::NeedsParentSync(_))
+      Some(crate::mmap_file::PendingDelete::NeedsUnlink { .. })
     ));
 
-    // Re-create the file. The retry MUST NOT delete this file — it would
-    // be deleting an unrelated occupant of the same path. The retry only
-    // syncs the parent (path-reuse safety).
+    // Re-create a different file at the same path. The retry's
+    // identity probe sees a different inode and surfaces a
+    // path-reuse error; pending state stays NeedsUnlink. The
+    // recreated file is preserved (we don't touch it).
     {
       let mut g = std::fs::File::create(&path).unwrap();
       use std::io::Write as _;
       g.write_all(b"different file").unwrap();
     }
 
-    f.remove().unwrap();
-    assert!(f.pending_drop_remove.is_none());
-    // The recreated file is preserved — NOT unlinked by the retry.
-    assert!(path.exists());
+    let err = f
+      .remove()
+      .expect_err("retry against path-reused file must NOT succeed");
+    assert!(
+      err.to_string().contains("path-reuse detected") || err.kind() == std::io::ErrorKind::NotFound,
+      "expected path-reuse or NotFound, got: {err}"
+    );
+    assert!(path.exists(), "recreated file must remain");
     assert_eq!(std::fs::read(&path).unwrap(), b"different file");
+    assert!(!f.deleted, "deleted must NOT be set on path-reuse retry");
   }
 
-  /// Codex finding (round 6, medium): when an explicit deletion (via
-  /// `remove(&mut self)` or consuming `drop_remove(self)`) failed, the
-  /// retained path was stored in `pending_remove_path`, which `Drop` only
-  /// honors under `remove_on_drop=true` — and a caller asking for delete
-  /// usually does NOT set that flag. Result: transient unlink failures
-  /// silently leaked the file. Verify the new `pending_drop_remove`
-  /// channel triggers Drop's retry regardless of `remove_on_drop`.
+  /// When an explicit deletion (via `remove(&mut self)` or consuming
+  /// `drop_remove(self)`) fails, an older implementation stored the
+  /// retained path in `pending_remove_path`, which `Drop` only honors
+  /// under `remove_on_drop=true` — and a caller asking for delete
+  /// usually does NOT set that flag. Result: transient unlink
+  /// failures silently leaked the file. Verify the
+  /// `pending_drop_remove` channel triggers Drop's retry regardless
+  /// of `remove_on_drop`.
   #[test]
   fn explicit_remove_failure_drop_retries_unconditionally() {
     let path = crate::tests::get_random_filename();
@@ -2203,14 +2324,13 @@ mod regression {
     let _ = std::fs::remove_file(&path);
   }
 
-  /// Codex finding (round 12, high): the public `lock()` and
-  /// `lock_shared()` methods used to call `fs4::FileExt::lock` /
-  /// `lock_shared` blindly. POSIX `flock` is idempotent on the same
-  /// handle, but Windows `LockFileEx` waits indefinitely for the same
-  /// handle to release — deadlock. Verify that calling `lock()` /
-  /// `lock_shared()` / `try_lock()` / `try_lock_shared()` on an
-  /// auto-locked wrapper is reentrant-safe (no-op when state matches,
-  /// `WouldBlock` when state mismatches).
+  /// The public `lock()` and `lock_shared()` methods used to call
+  /// `fs4::FileExt::lock` / `lock_shared` blindly. POSIX `flock` is
+  /// idempotent on the same handle, but Windows `LockFileEx` waits
+  /// indefinitely for the same handle to release — deadlock. Verify
+  /// that calling `lock()` / `lock_shared()` / `try_lock()` /
+  /// `try_lock_shared()` on an auto-locked wrapper is reentrant-safe
+  /// (no-op when state matches, `WouldBlock` when state mismatches).
   #[test]
   fn reentrant_lock_methods_do_not_deadlock_on_auto_lock() {
     let path = crate::tests::get_random_filename();
@@ -2243,41 +2363,104 @@ mod regression {
     unsafe { f.unlock() }.unwrap();
   }
 
-  /// Codex finding (round 9, high): durable unlink retry was not
-  /// idempotent — after the first attempt unlinked the inode but failed
-  /// `sync_dir`, the retry's `remove_file` would hit NotFound and never
-  /// fsync the parent, so the unlink could still be lost on crash. Verify
-  /// the retry path now treats NotFound as "already unlinked, just finish
-  /// parent sync". Also verify basename paths (empty parent) still get
-  /// synced via `.`.
+  /// Durable unlink retry must be idempotent — after the first
+  /// attempt unlinks the inode but fails `sync_dir`, the retry's
+  /// parent fsync should still complete so the unlink isn't lost on
+  /// crash. Verify `NeedsParentSync` retries fsync-only and reports
+  /// success.
+  ///
+  /// We directly construct `NeedsParentSync` to exercise the
+  /// post-unlink path. (A test that pre-deletes the path and relies
+  /// on initial-call NotFound to produce `NeedsParentSync` does not
+  /// work, because pre-unlink NotFound is correctly routed to
+  /// `NeedsUnlink` — a renamed-away file isn't deleted, so that
+  /// setup wouldn't reach the NeedsParentSync code path.)
   #[test]
   fn pending_drop_remove_retry_tolerates_already_unlinked() {
     let path = crate::tests::get_random_filename();
     defer!(let _ = std::fs::remove_file(&path););
     let mut f = unsafe { MmapFileMut::create(&path) }.unwrap();
     f.truncate(8).unwrap();
-
-    // First, force the initial remove to fail by pre-deleting (NotFound).
     drop(std::fs::remove_file(&path));
-    assert!(f.remove().is_err());
-    assert!(f.pending_drop_remove.is_some());
 
-    // Now there's NO file at `path` (we pre-deleted). The retry must NOT
-    // fail with NotFound — it must treat the missing file as "already
-    // unlinked" and finish by syncing the parent. This proves the
-    // post-unlink-pre-sync recovery window is closed.
+    // Pre-open a parent handle to construct NeedsParentSync directly,
+    // mirroring the post-unlink-pre-sync state initial_remove_durably
+    // would have reached if `unlinkat` succeeded but
+    // `sync_parent_handle` failed. The path is gone (we pre-deleted it
+    // above) — the retry must still complete via parent fsync alone
+    // and clear the pending state.
+    let parent_handle = crate::utils::open_parent_for_sync(&path)
+      .expect("open parent for NeedsParentSync test fixture");
+    f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsParentSync {
+      path: path.clone(),
+      parent_handle,
+    });
+
     f.remove().unwrap();
     assert!(f.pending_drop_remove.is_none());
     assert!(f.deleted);
   }
 
-  /// Codex finding (round 8, high): `Drop` used to call `remove_file` on
-  /// `inner.path_buf()` whenever `remove_on_drop=true`, regardless of
-  /// inner variant. Memory variants store the user-supplied string as a
-  /// label, so `MmapFileMut::memory_from_vec("real_file", ...)` followed
-  /// by `set_remove_on_drop(true)` would delete `real_file` on Drop even
-  /// though no on-disk mapping owns it. Verify Drop now no-ops on Memory
-  /// variants (matching the explicit `remove()` method's behavior).
+  /// Pre-unlink NotFound after a *rename* (not an unlink) must keep
+  /// `NeedsUnlink` and never mark `deleted = true`. The pin's inode
+  /// is alive at the rename destination (`nlink > 0`), so the nlink
+  /// classifier correctly stays in NeedsUnlink. A `NeedsParentSync`
+  /// route would let the next retry trivially fsync and report
+  /// success while the original file is still alive at a new name.
+  #[cfg(unix)]
+  #[test]
+  fn pre_unlink_notfound_after_rename_keeps_needs_unlink() {
+    let path = crate::tests::get_random_filename();
+    let mut renamed = crate::tests::get_random_filename();
+    renamed.set_extension("renamed");
+    defer!(let _ = std::fs::remove_file(&path););
+    defer!(let _ = std::fs::remove_file(&renamed););
+    let mut f = unsafe { MmapFileMut::create(&path) }.unwrap();
+    f.truncate(8).unwrap();
+
+    // Rename the file away — directory entry at `path` is gone, but
+    // the inode lives on at `renamed` (nlink stays at 1).
+    std::fs::rename(&path, &renamed).unwrap();
+    assert!(!path.exists());
+    assert!(renamed.exists());
+
+    // First remove() — pre-unlink probe at `path` is NotFound.
+    // fstat on the pin sees nlink == 1 (alive at `renamed`), so we
+    // route to NeedsUnlink (the rename-then-NotFound case).
+    let err = f.remove().expect_err("path missing → NotFound");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    assert!(matches!(
+      f.pending_drop_remove,
+      Some(crate::mmap_file::PendingDelete::NeedsUnlink { .. })
+    ));
+    assert!(!f.deleted, "deleted must NOT be set on initial NotFound");
+
+    // Retry — still missing at `path`, still alive at `renamed`,
+    // still NeedsUnlink. No false-success.
+    let err = f
+      .remove()
+      .expect_err("retry against renamed-away file stays NotFound");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    assert!(matches!(
+      f.pending_drop_remove,
+      Some(crate::mmap_file::PendingDelete::NeedsUnlink { .. })
+    ));
+    assert!(
+      !f.deleted,
+      "false-success on retry: the renamed-away file is still alive, deletion did not happen"
+    );
+    // The renamed-away file is still alive — we never touched it.
+    assert!(renamed.exists());
+  }
+
+  /// `Drop` used to call `remove_file` on `inner.path_buf()` whenever
+  /// `remove_on_drop=true`, regardless of inner variant. Memory
+  /// variants store the user-supplied string as a label, so
+  /// `MmapFileMut::memory_from_vec("real_file", ...)` followed by
+  /// `set_remove_on_drop(true)` would delete `real_file` on Drop
+  /// even though no on-disk mapping owns it. Verify Drop now no-ops
+  /// on Memory variants (matching the explicit `remove()` method's
+  /// behavior).
   #[test]
   fn drop_on_memory_variant_does_not_unlink_label_path() {
     let real_file_path = crate::tests::get_random_filename();
@@ -2302,12 +2485,12 @@ mod regression {
     let _ = std::fs::remove_file(&real_file_path);
   }
 
-  /// Codex finding (round 7, high): `freeze`/`freeze_exec` on
-  /// `DiskMmapFileMut` did not check the `poisoned` flag, so a failed
-  /// truncate could be turned into a successful read-only `MmapFile`
-  /// whose `as_slice()` returns the anonymous placeholder bytes while
-  /// `path()`/`metadata()` refer to the real file — silently corrupt
-  /// views. Verify `freeze` and `freeze_exec` reject a poisoned mapping.
+  /// `freeze`/`freeze_exec` on `DiskMmapFileMut` must check the
+  /// `poisoned` flag — otherwise a failed truncate could be turned
+  /// into a successful read-only `MmapFile` whose `as_slice()`
+  /// returns the anonymous placeholder bytes while `path()`/
+  /// `metadata()` refer to the real file — silently corrupt views.
+  /// Verify `freeze` and `freeze_exec` reject a poisoned mapping.
   #[test]
   fn freeze_rejects_poisoned_mapping() {
     use crate::raw::DiskMmapFileMut;
@@ -2342,13 +2525,13 @@ mod regression {
     );
   }
 
-  /// Codex finding (round 5, high): consuming `drop_remove(self)` swapped
-  /// inner to Empty BEFORE running fallible disk I/O. On Err the wrapper
-  /// was consumed and `Drop`'s `remove_on_drop` cleanup silently no-op'd
-  /// against the Empty inner's `""` path. Verify `drop_remove` propagates
-  /// the Err (the `pending_remove_path` retention is verified by the
-  /// inherent-`remove` regression above; the consuming variant uses the
-  /// same retain-on-Err shape).
+  /// Consuming `drop_remove(self)` used to swap inner to Empty BEFORE
+  /// running fallible disk I/O. On Err the wrapper was consumed and
+  /// `Drop`'s `remove_on_drop` cleanup silently no-op'd against the
+  /// Empty inner's `""` path. Verify `drop_remove` propagates the
+  /// Err (the `pending_remove_path` retention is verified by the
+  /// inherent-`remove` regression above; the consuming variant uses
+  /// the same retain-on-Err shape).
   #[test]
   fn drop_remove_consuming_propagates_failure() {
     let path = crate::tests::get_random_filename();
@@ -2383,11 +2566,12 @@ mod regression {
     assert_eq!(bytes, b"abcd");
   }
 
-  /// Codex finding (high): a copy-on-write mapping must not mutate the
-  /// backing file. Both `close(max_sz)` (inherent) and `close_with_truncate`
-  /// (trait, dispatching to disk) used to call `set_len` on the backing file
-  /// regardless of mapping type. Verify both paths refuse with Unsupported
-  /// when `max_sz >= 0` AND the underlying file is preserved.
+  /// A copy-on-write mapping must not mutate the backing file. Both
+  /// `close(max_sz)` (inherent) and `close_with_truncate` (trait,
+  /// dispatching to disk) used to call `set_len` on the backing file
+  /// regardless of mapping type. Verify both paths refuse with
+  /// Unsupported when `max_sz >= 0` AND the underlying file is
+  /// preserved.
   #[test]
   fn cow_close_does_not_truncate_backing_file() {
     let path = crate::tests::get_random_filename();
@@ -2423,13 +2607,14 @@ mod regression {
     assert_eq!(std::fs::read(&path).unwrap(), b"keep me intact");
   }
 
-  /// Codex finding (round 14, critical): `Options::len` was previously
-  /// passed straight to memmapix without bounds-checking against the
-  /// backing file. memmapix accepts the configured length unconditionally,
-  /// so a 4096-byte mapping over a 1-byte file produces a mapping whose
-  /// pages past EOF SIGBUS on access — turning a safe-API entry point
-  /// into an unannounced UB trap. Verify each constructor rejects an
-  /// `offset+len` window that exceeds the file before invoking memmapix.
+  /// `Options::len` was previously passed straight to memmapix
+  /// without bounds-checking against the backing file. memmapix
+  /// accepts the configured length unconditionally, so a 4096-byte
+  /// mapping over a 1-byte file produces a mapping whose pages past
+  /// EOF SIGBUS on access — turning a safe-API entry point into an
+  /// unannounced UB trap. Verify each constructor rejects an
+  /// `offset+len` window that exceeds the file before invoking
+  /// memmapix.
   #[test]
   fn map_range_validation_rejects_oversized_window() {
     use crate::Options;
@@ -2481,13 +2666,13 @@ mod regression {
     assert_eq!(f.as_slice(), b"bc");
   }
 
-  /// Codex finding (round 14, high): the raw `DiskMmapFileMut::drop_remove`
-  /// is consuming and used to return parent-fsync errors in a generic
-  /// shape, so a caller couldn't tell unlink-failed from unlink-succeeded-
-  /// but-parent-sync-failed and would be tempted to retry `remove_file` on
-  /// a path that may have been reused. Verify the post-unlink failure is
-  /// reported with a message that names the parent dir and warns against
-  /// re-calling `remove_file`.
+  /// The raw `DiskMmapFileMut::drop_remove` is consuming and used to
+  /// return parent-fsync errors in a generic shape, so a caller
+  /// couldn't tell unlink-failed from
+  /// unlink-succeeded-but-parent-sync-failed and would be tempted to
+  /// retry `remove_file` on a path that may have been reused. Verify
+  /// the post-unlink failure is reported with a message that names
+  /// the parent dir and warns against re-calling `remove_file`.
   ///
   /// Triggering an actual `sync_dir` failure is intrusive (mocking fsync),
   /// so this test only covers the success path of the message-tagging code:
@@ -2507,11 +2692,11 @@ mod regression {
     assert!(!path.exists(), "file should be unlinked");
   }
 
-  /// Codex finding (round 15, high): `open_with_options` used to apply
-  /// `truncate(true)` and `max_size` extension *before* validating the
-  /// mapping range. An invalid `offset/len` combined with `truncate(true)`
-  /// would zero an existing file and only then return Err — silent data
-  /// loss. Verify the file content is preserved when validation rejects.
+  /// `open_with_options` used to apply `truncate(true)` and
+  /// `max_size` extension *before* validating the mapping range. An
+  /// invalid `offset/len` combined with `truncate(true)` would zero
+  /// an existing file and only then return Err — silent data loss.
+  /// Verify the file content is preserved when validation rejects.
   #[test]
   fn invalid_options_with_truncate_preserve_existing_file() {
     use crate::Options;
@@ -2551,12 +2736,11 @@ mod regression {
     );
   }
 
-  /// Round 17 regression: `pending_remove_path` (set when
-  /// `close_with_truncate` consumed the inner) does NOT carry identity
-  /// — by that point the `File` was already gone — so its Drop path
-  /// stays the path-reuse-safe "fsync parent only" behavior introduced
-  /// in round 16. Verify a wrapper whose only Drop signal is
-  /// `pending_remove_path` does not unlink.
+  /// `pending_remove_path` (set when `close_with_truncate` consumed
+  /// the inner) does NOT carry identity — by that point the `File`
+  /// was already gone — so its Drop path is the path-reuse-safe
+  /// "fsync parent only" behavior. Verify a wrapper whose only Drop
+  /// signal is `pending_remove_path` does not unlink.
   #[test]
   fn pending_remove_path_drop_does_not_unlink() {
     let path = crate::tests::get_random_filename();
@@ -2575,29 +2759,24 @@ mod regression {
     assert_eq!(std::fs::read(&path).unwrap(), b"keep");
   }
 
-  /// Codex finding (round 15, high): `drop_complete_pending_delete` used
-  /// to retry `remove_file` from `Drop` when state was `NeedsUnlink`,
-  /// which races path reuse — between the initial failure and Drop,
-  /// another actor could swap the path and our retry would delete an
-  /// unrelated file. Verify Drop no longer unlinks by path alone.
+  /// `drop_complete_pending_delete` used to retry `remove_file` from
+  /// `Drop` when state was `NeedsUnlink`, which races path reuse —
+  /// between the initial failure and Drop, another actor could swap
+  /// the path and our retry would delete an unrelated file. Verify
+  /// Drop no longer unlinks by path alone.
   ///
-  /// Construction: induce a `NeedsUnlink` pending state by pre-deleting
-  /// the file to make the explicit `drop_remove()` fail with a typed
-  /// non-NotFound error. (We can't easily provoke a non-NotFound failure
-  /// in tests without privilege escalation; instead we directly install
-  /// the pending state and observe Drop behavior.)
-  /// Codex round 17 (high) regression: explicit `remove()` retry of a
-  /// `NeedsUnlink` pending state must verify file identity (POSIX
-  /// dev+ino) before unlinking. If the path was reused between failure
-  /// and retry, retry must NOT delete the unrelated occupant.
+  /// Construction: induce a `NeedsUnlink` pending state by
+  /// pre-deleting the file to make the explicit `drop_remove()` fail
+  /// with a typed non-NotFound error. (We can't easily provoke a
+  /// non-NotFound failure in tests without privilege escalation;
+  /// instead we directly install the pending state and observe Drop
+  /// behavior.)
   ///
-  /// POSIX-only: on stable Rust, the natural Windows identity
-  /// (`file_index`) lives behind the unstable `windows_by_handle`
-  /// feature, so Windows uses a placeholder identity that trivially
-  /// matches and proceeds with the unlink — the path-reuse race is a
-  /// documented Windows limitation. POSIX has dev+ino so we can prove
-  /// the refusal path.
-  #[cfg(unix)]
+  /// Explicit `remove()` retry of a `NeedsUnlink` pending state must
+  /// verify file identity before unlinking. If the path was reused
+  /// between failure and retry, retry must NOT delete the unrelated
+  /// occupant. POSIX uses dev+ino; Windows uses
+  /// `GetFileInformationByHandle`'s volume serial + file index.
   #[test]
   fn explicit_retry_with_identity_check_refuses_path_reused_file() {
     let probe_path = crate::tests::get_random_filename();
@@ -2614,8 +2793,7 @@ mod regression {
     let mut original = original;
     original.write_all(b"original").unwrap();
     original.sync_all().unwrap();
-    let original_identity =
-      crate::utils::FileIdentity::from_metadata(&original.metadata().unwrap());
+    let original_identity = crate::utils::FileIdentity::from_file(&original).unwrap();
     // Unlink the directory entry but keep the inode pinned via `original`.
     std::fs::remove_file(&probe_path).unwrap();
     // Plant a *different* file at the same path. With `original` still
@@ -2626,6 +2804,8 @@ mod regression {
     f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsUnlink {
       path: probe_path.clone(),
       identity: original_identity,
+      #[cfg(unix)]
+      pin: dup_for_pin(&original),
     });
 
     let err = f.remove().unwrap_err();
@@ -2645,7 +2825,7 @@ mod regression {
     drop(original);
   }
 
-  /// Round 17: with a matching identity, retry succeeds and unlinks.
+  /// With a matching identity, retry succeeds and unlinks.
   #[test]
   fn explicit_retry_with_matching_identity_unlinks() {
     let probe_path = crate::tests::get_random_filename();
@@ -2653,18 +2833,21 @@ mod regression {
 
     // Create the file and capture its identity. Don't delete it; the
     // path still names the same inode, so retry must succeed.
-    let identity = {
-      let mut f = std::fs::File::create(&probe_path).unwrap();
-      f.write_all(b"to-be-deleted").unwrap();
-      f.sync_all().unwrap();
-      crate::utils::FileIdentity::from_metadata(&f.metadata().unwrap())
-    };
+    let mut original = std::fs::File::create(&probe_path).unwrap();
+    original.write_all(b"to-be-deleted").unwrap();
+    original.sync_all().unwrap();
+    let identity = crate::utils::FileIdentity::from_file(&original).unwrap();
+    #[cfg(unix)]
+    let pin = dup_for_pin(&original);
+    drop(original);
     assert!(probe_path.exists());
 
     let mut f = MmapFileMut::memory_from_vec("dummy.mem", vec![1u8]);
     f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsUnlink {
       path: probe_path.clone(),
       identity,
+      #[cfg(unix)]
+      pin,
     });
 
     f.remove().expect("identity matches → retry must unlink");
@@ -2672,11 +2855,119 @@ mod regression {
     assert!(f.pending_drop_remove.is_none());
   }
 
-  /// Round 17: Drop's pending-delete path must verify identity before
-  /// unlinking. With identity captured from the *original* file but the
-  /// path now naming a different inode, Drop must leave it alone.
-  /// POSIX-only — see sibling test for the Windows-stable rationale.
+  /// POSIX unlink permission is controlled by the parent dir, not by
+  /// the file's mode bits — a `chmod 000` file in a writable parent
+  /// must still be removable through fmmap's identity-checked path.
+  /// A previous implementation opened the file to probe identity and
+  /// so failed with EACCES on unreadable files; we now use
+  /// `metadata()` (stat), which only needs execute on the parent dir.
   #[cfg(unix)]
+  #[test]
+  fn unix_identity_check_works_on_chmod_000_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let probe_path = crate::tests::get_random_filename();
+    defer!(let _ = {
+      // Restore perms in case the test panics mid-way; otherwise the
+      // tempfile cleanup helper can't remove the file.
+      let _ = std::fs::set_permissions(&probe_path, std::fs::Permissions::from_mode(0o600));
+      std::fs::remove_file(&probe_path)
+    };);
+
+    // Create the file, dup for the inode pin, capture identity.
+    let original = std::fs::File::create(&probe_path).unwrap();
+    let identity = crate::utils::FileIdentity::from_file(&original).unwrap();
+    let pin = dup_for_pin(&original);
+    drop(original);
+    // Strip all permissions on the file. The parent dir (typically
+    // /tmp with 0o1777 or similar) still permits unlink.
+    std::fs::set_permissions(&probe_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Identity probe via from_path uses metadata() now — works without
+    // read permission.
+    let probe = crate::utils::FileIdentity::from_path(&probe_path)
+      .expect("metadata-based identity probe must succeed for chmod 000 file");
+    assert!(identity.is_known_equal(&probe));
+    assert!(identity.matches_path(&probe_path));
+
+    // Wrap in PendingDelete and verify retry's identity check + unlink
+    // succeeds (the parent dir is writable, the file is unreadable).
+    let mut f = MmapFileMut::memory_from_vec("dummy.mem", vec![1u8]);
+    f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsUnlink {
+      path: probe_path.clone(),
+      identity,
+      pin,
+    });
+    f.remove()
+      .expect("chmod 000 file must still be removable via identity-checked retry");
+    assert!(!probe_path.exists());
+  }
+
+  /// When the user passes a symlink path, `remove_file(path)`
+  /// removes only the symlink, not the target — so even with
+  /// matching identity (the probe and the open file both follow the
+  /// symlink to the same inode), the wrapper would otherwise
+  /// succeed-and-leave-the-real-file-behind. Verify that
+  /// identity-checked cleanup refuses symlink paths instead.
+  #[cfg(unix)]
+  #[test]
+  fn identity_check_refuses_symlink_path() {
+    use std::os::unix::fs::symlink;
+
+    let target_path = crate::tests::get_random_filename();
+    let mut symlink_path = crate::tests::get_random_filename();
+    symlink_path.set_extension("symlink");
+    defer!(let _ = std::fs::remove_file(&target_path););
+    defer!(let _ = std::fs::remove_file(&symlink_path););
+
+    // Create the real file and a symlink pointing at it.
+    {
+      let f = std::fs::File::create(&target_path).unwrap();
+      drop(f);
+    }
+    symlink(&target_path, &symlink_path).unwrap();
+
+    // Capture identity through the symlink (follows). Both target and
+    // symlink resolve to the same inode, so the matching-identity
+    // happy path would otherwise green-light deletion.
+    let original = std::fs::File::open(&symlink_path).unwrap();
+    let identity = crate::utils::FileIdentity::from_file(&original).unwrap();
+    let pin = dup_for_pin(&original);
+    drop(original);
+    // matches_path: symlink_metadata sees the link itself → refuse.
+    assert!(
+      !identity.matches_path(&symlink_path),
+      "matches_path must refuse when path is a symlink",
+    );
+
+    // The from_path probe directly reports the symlink-refusal error.
+    let err = crate::utils::FileIdentity::from_path(&symlink_path).unwrap_err();
+    assert!(
+      err.to_string().contains("refuses to follow symlink"),
+      "expected symlink-refusal error, got: {err}",
+    );
+
+    // Plumbed through the wrapper: a NeedsUnlink retry against a
+    // symlink path must NOT remove the symlink (or the target).
+    let mut f = MmapFileMut::memory_from_vec("dummy.mem", vec![1u8]);
+    f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsUnlink {
+      path: symlink_path.clone(),
+      identity,
+      pin,
+    });
+    let err = f.remove().unwrap_err();
+    assert!(
+      err.to_string().contains("refuses to follow symlink")
+        || err.to_string().contains("path-reuse detected"),
+      "expected symlink/path-reuse refusal, got: {err}",
+    );
+    assert!(symlink_path.exists(), "symlink must remain");
+    assert!(target_path.exists(), "target must remain");
+  }
+
+  /// Drop's pending-delete path must verify identity before
+  /// unlinking. With identity captured from the *original* file but
+  /// the path now naming a different inode, Drop must leave it alone.
   #[test]
   fn drop_does_not_unlink_path_reused_file_for_needs_unlink() {
     let probe_path = crate::tests::get_random_filename();
@@ -2690,8 +2981,7 @@ mod regression {
     let mut original = original;
     original.write_all(b"original").unwrap();
     original.sync_all().unwrap();
-    let original_identity =
-      crate::utils::FileIdentity::from_metadata(&original.metadata().unwrap());
+    let original_identity = crate::utils::FileIdentity::from_file(&original).unwrap();
     std::fs::remove_file(&probe_path).unwrap();
     std::fs::write(&probe_path, b"unrelated content").unwrap();
 
@@ -2700,6 +2990,8 @@ mod regression {
       f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsUnlink {
         path: probe_path.clone(),
         identity: original_identity,
+        #[cfg(unix)]
+        pin: dup_for_pin(&original),
       });
       drop(f);
     }
@@ -2712,20 +3004,21 @@ mod regression {
     drop(original);
   }
 
-  /// Round 17: complement to the above — when identity matches, Drop's
-  /// pending-delete path *does* unlink (the cleanup that Codex round 16
-  /// disabled is now safely re-enabled by identity verification).
+  /// Complement to the above — when identity matches, Drop's
+  /// pending-delete path *does* unlink, now safely guarded by
+  /// identity verification.
   #[test]
   fn drop_unlinks_when_identity_matches() {
     let probe_path = crate::tests::get_random_filename();
     defer!(let _ = std::fs::remove_file(&probe_path););
 
-    let identity = {
-      let mut f = std::fs::File::create(&probe_path).unwrap();
-      f.write_all(b"to-be-deleted").unwrap();
-      f.sync_all().unwrap();
-      crate::utils::FileIdentity::from_metadata(&f.metadata().unwrap())
-    };
+    let mut original = std::fs::File::create(&probe_path).unwrap();
+    original.write_all(b"to-be-deleted").unwrap();
+    original.sync_all().unwrap();
+    let identity = crate::utils::FileIdentity::from_file(&original).unwrap();
+    #[cfg(unix)]
+    let pin = dup_for_pin(&original);
+    drop(original);
     assert!(probe_path.exists());
 
     {
@@ -2733,6 +3026,8 @@ mod regression {
       f.pending_drop_remove = Some(crate::mmap_file::PendingDelete::NeedsUnlink {
         path: probe_path.clone(),
         identity,
+        #[cfg(unix)]
+        pin,
       });
       drop(f);
     }
@@ -2743,19 +3038,15 @@ mod regression {
     );
   }
 
-  /// Codex round 18 (high) regression: the *initial* `remove()` /
-  /// `drop_remove()` call must identity-check before `remove_file`.
-  /// Between the wrapper dropping its file handle and the unlink, an
-  /// outside actor could rename + recreate the path with a different
-  /// file. Without the check, the initial unlink would delete that
-  /// unrelated file. Simulate the race by:
+  /// The *initial* `remove()` / `drop_remove()` call must
+  /// identity-check before `remove_file`. Between the wrapper
+  /// dropping its file handle and the unlink, an outside actor could
+  /// rename + recreate the path with a different file. Without the
+  /// check, the initial unlink would delete that unrelated file.
+  /// Simulate the race by:
   ///   1. opening the wrapper (captures identity from the original inode),
   ///   2. externally swapping the path with a different file,
   ///   3. calling `remove()`, which must refuse to unlink.
-  ///
-  /// POSIX-only — Windows-stable lacks file_index identity (see sibling
-  /// `explicit_retry_with_identity_check_refuses_path_reused_file`).
-  #[cfg(unix)]
   #[test]
   fn initial_remove_refuses_path_reused_file() {
     let path = crate::tests::get_random_filename();
@@ -2787,10 +3078,9 @@ mod regression {
     ));
   }
 
-  /// Codex round 18 (high) regression: same race, but for raw
-  /// `DiskMmapFileMut::drop_remove`. The raw API must not unlink either.
-  /// POSIX-only — see sibling for the Windows-stable rationale.
-  #[cfg(unix)]
+  /// Same race as the wrapper test, but for raw
+  /// `DiskMmapFileMut::drop_remove`. The raw API must not unlink
+  /// either.
   #[test]
   fn raw_drop_remove_refuses_path_reused_file() {
     use crate::raw::DiskMmapFileMut;
@@ -2816,9 +3106,8 @@ mod regression {
     assert_eq!(std::fs::read(&path).unwrap(), b"unrelated content");
   }
 
-  /// Round 17: `remove_on_drop` direct path now verifies identity from the
-  /// inner before unlinking — round-16 disabled this entirely; round-17
-  /// re-enables it safely. Verify the file IS unlinked when the path
+  /// `remove_on_drop` direct path verifies identity from the inner
+  /// before unlinking. Verify the file IS unlinked when the path
   /// still names the same inode at Drop time.
   #[test]
   fn remove_on_drop_unlinks_when_identity_matches() {

--- a/fmmap/src/mmap_file/tokio_impl.rs
+++ b/fmmap/src/mmap_file/tokio_impl.rs
@@ -13,7 +13,65 @@ use std::{
   mem,
   path::{Path, PathBuf},
 };
-use tokio::{fs::remove_file, io::AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
+
+/// Run a blocking IO closure on tokio's blocking thread pool. Used by
+/// the durable-delete path to keep `unlinkat` + `fsync` off the async
+/// executor thread. If the closure panics, the panic is propagated
+/// (matches the behavior the caller would see for a synchronous call).
+async fn run_blocking_io<F, T>(f: F) -> T
+where
+  F: FnOnce() -> T + Send + 'static,
+  T: Send + 'static,
+{
+  match tokio::task::spawn_blocking(f).await {
+    Ok(r) => r,
+    Err(e) => std::panic::resume_unwind(e.into_panic()),
+  }
+}
+
+/// Extract the inode pin used by the durable-delete path from an
+/// async file, returning the original file on failure so the wrapper
+/// can restore `self.inner` and let the caller retry.
+///
+/// tokio: `tokio::fs::File::into_std` moves the underlying
+/// `std::fs::File` out without allocating a new fd. Infallible for
+/// fd-pressure reasons — `drop_remove(self)` and `remove(&mut self)`
+/// cannot fail with EMFILE on tokio.
+#[cfg(unix)]
+async fn extract_pin_or_err(
+  file: ::tokio::fs::File,
+) -> std::result::Result<std::fs::File, (::tokio::fs::File, Error)> {
+  Ok(file.into_std().await)
+}
+
+/// Synchronous variant of the inode-pin extraction used by
+/// `impl_drop!`'s `remove_on_drop` path. Drop runs in a sync context
+/// — we can't `await` here. tokio's `try_into_std` is sync and
+/// returns the inner `std::fs::File` directly when there are no
+/// in-flight ops; we fall back to `fcntl_dupfd_cloexec` if it does
+/// (rare for a wrapper at Drop time). On EMFILE the file leaks
+/// (Drop is best-effort); same constraint as the smol raw path.
+#[cfg(unix)]
+fn sync_drop_pin(file: ::tokio::fs::File) -> Option<std::fs::File> {
+  match file.try_into_std() {
+    Ok(std_file) => Some(std_file),
+    Err(orig) => {
+      use std::os::fd::{AsRawFd, BorrowedFd};
+      let raw = orig.as_raw_fd();
+      // SAFETY: orig is alive for the duration of the borrow.
+      let borrowed = unsafe { BorrowedFd::borrow_raw(raw) };
+      rustix::io::fcntl_dupfd_cloexec(borrowed, 0)
+        .ok()
+        .map(std::fs::File::from)
+    }
+  }
+}
+#[cfg(not(unix))]
+fn sync_drop_pin(file: ::tokio::fs::File) -> Option<std::fs::File> {
+  drop(file);
+  None
+}
 
 declare_async_mmap_file_ext!(
   AsyncDiskMmapFileMut,

--- a/fmmap/src/tests.rs
+++ b/fmmap/src/tests.rs
@@ -1169,9 +1169,9 @@ mod axync {
     assert!(!path.exists());
   }
 
-  /// Codex round 15 (high) regression: async open_with_options used to
-  /// truncate before validating the mapping range. Verify a tokio caller
-  /// cannot lose existing file content when options are invalid.
+  /// async open_with_options used to truncate before validating the
+  /// mapping range. Verify a tokio caller cannot lose existing file
+  /// content when options are invalid.
   #[tokio::test]
   async fn async_invalid_options_with_truncate_preserve_existing_file() {
     use crate::tokio::AsyncOptions;
@@ -1563,9 +1563,8 @@ mod smol_tests {
     let _ = unsafe { f.unlock() };
   }
 
-  /// Codex round 15 (high) regression: see tokio counterpart. Validates
-  /// the smol async path also rejects invalid options before destructive
-  /// truncation.
+  /// See tokio counterpart. Validates the smol async path also
+  /// rejects invalid options before destructive truncation.
   #[smol_potat::test]
   async fn smol_invalid_options_with_truncate_preserve_existing_file() {
     use crate::smol::AsyncOptions;

--- a/fmmap/src/utils.rs
+++ b/fmmap/src/utils.rs
@@ -100,6 +100,271 @@ pub(crate) fn open_parent_for_sync(path: &Path) -> Result<std::fs::File> {
   }
 }
 
+/// Probe identity *relative to the open parent dir handle* on POSIX
+/// using `fstatat`, falling back to path-based `from_path` on other
+/// platforms.
+///
+/// Why parent-bound: mixing `open_parent_for_sync(path)`,
+/// `metadata(path)`, `remove_file(path)`, and
+/// `parent_handle.sync_all()` lets a parent-rename race make the
+/// fsync claim durability for a different directory than the one the
+/// unlink actually went through. Doing the probe AND the unlink (via
+/// `unlink_at_or_path`) relative to the same `parent_handle` keeps all
+/// three operations bound to the same parent inode.
+///
+/// On non-POSIX (Windows) we don't have a robust openat-equivalent
+/// without major contortions, so we fall back to path-based — see the
+/// Windows residual race documented in `FileIdentity`.
+#[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
+pub(crate) fn identity_at_or_path(
+  parent: &std::fs::File,
+  full_path: &Path,
+) -> Result<FileIdentity> {
+  #[cfg(unix)]
+  {
+    use rustix::fs::{AtFlags, FileType};
+    let basename = full_path.file_name().ok_or_else(|| {
+      Error::new(
+        ErrorKind::InvalidInput,
+        "path has no basename (cannot statat)",
+      )
+    })?;
+    let stat = rustix::fs::statat(parent, basename, AtFlags::SYMLINK_NOFOLLOW)
+      .map_err(std::io::Error::from)?;
+    if FileType::from_raw_mode(stat.st_mode as _) == FileType::Symlink {
+      return Err(Error::other(format!(
+        "identity-checked delete refuses to follow symlink at '{}': remove_file would unlink the symlink, not the target.",
+        full_path.display(),
+      )));
+    }
+    Ok(FileIdentity {
+      dev: stat.st_dev as u64,
+      ino: stat.st_ino as u64,
+    })
+  }
+  #[cfg(not(unix))]
+  {
+    let _ = parent;
+    FileIdentity::from_path(full_path)
+  }
+}
+
+/// Unlink the file in a path-reuse-safe way, bound to a single
+/// kernel-verified handle wherever possible.
+///
+/// **POSIX**: `unlinkat(parent_fd, basename, 0)`. Bound to the same
+/// parent inode that `sync_parent_handle(parent)` will fsync — the
+/// unlink is durable for the directory the entry was actually removed
+/// from even if the parent path was renamed mid-operation. The
+/// `expected_identity` param is unused here: the caller's
+/// `identity_at_or_path` already verified, and there's no kernel API
+/// to bind unlink to inode (vs name).
+///
+/// **Windows**: a path-based fallback (`std::fs::remove_file(path)`)
+/// would have a TOCTOU between identity probe and delete — the probe
+/// handle is closed, then `remove_file` re-opens the path, so a swap
+/// in between could delete an unrelated replacement. This path
+/// instead opens with `DELETE | FILE_SHARE_*` access and
+/// `FILE_FLAG_OPEN_REPARSE_POINT`, re-verifies identity (and refuses
+/// reparse points) on the handle, then issues
+/// `SetFileInformationByHandle(FileDispositionInfo)`. The identity
+/// check and the unlink are bound to the same handle — no race.
+/// `expected_identity` is the value to verify against.
+///
+/// `parent` is unused on Windows (kept for cross-platform signature
+/// parity).
+#[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
+pub(crate) fn unlink_at_or_path(
+  parent: &std::fs::File,
+  full_path: &Path,
+  expected_identity: FileIdentity,
+) -> Result<()> {
+  #[cfg(unix)]
+  {
+    let _ = expected_identity;
+    use rustix::fs::AtFlags;
+    let basename = full_path.file_name().ok_or_else(|| {
+      Error::new(
+        ErrorKind::InvalidInput,
+        "path has no basename (cannot unlinkat)",
+      )
+    })?;
+    rustix::fs::unlinkat(parent, basename, AtFlags::empty()).map_err(std::io::Error::from)?;
+    Ok(())
+  }
+  #[cfg(windows)]
+  {
+    let _ = parent;
+    use ::windows_sys::Win32::Storage::FileSystem::{
+      FileBasicInfo, FileDispositionInfo, FileDispositionInfoEx, GetFileInformationByHandleEx,
+      ReOpenFile, SetFileInformationByHandle, FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_READONLY,
+      FILE_BASIC_INFO, FILE_DISPOSITION_FLAG_DELETE,
+      FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE, FILE_DISPOSITION_FLAG_POSIX_SEMANTICS,
+      FILE_DISPOSITION_INFO, FILE_DISPOSITION_INFO_EX,
+    };
+    use std::os::windows::{
+      fs::{MetadataExt, OpenOptionsExt},
+      io::{AsRawHandle, FromRawHandle},
+    };
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x00200000;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x00000400;
+    const DELETE_ACCESS: u32 = 0x00010000;
+    const FILE_WRITE_ATTRIBUTES: u32 = 0x00000100;
+    const FILE_SHARE_READ: u32 = 0x00000001;
+    const FILE_SHARE_WRITE: u32 = 0x00000002;
+    const FILE_SHARE_DELETE: u32 = 0x00000004;
+    const INVALID_HANDLE_VALUE: isize = -1;
+    // Open the primary delete handle with DELETE only.
+    // FileDispositionInfoEx requires only DELETE access; requesting
+    // FILE_WRITE_ATTRIBUTES upfront would fail at open for ACLs that
+    // grant delete-only — and the Ex path's
+    // IGNORE_READONLY_ATTRIBUTE flag means we never need
+    // FILE_WRITE_ATTRIBUTES on this handle. The fallback re-opens
+    // via ReOpenFile to add FILE_WRITE_ATTRIBUTES only when needed.
+    // FILE_FLAG_OPEN_REPARSE_POINT means we get a handle to the
+    // reparse entry itself if present, so the
+    // FILE_ATTRIBUTE_REPARSE_POINT check below catches
+    // symlinks/junctions before we delete them.
+    let file = std::fs::OpenOptions::new()
+      .access_mode(DELETE_ACCESS)
+      .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+      .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+      .open(full_path)?;
+    let meta = file.metadata()?;
+    if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+      return Err(Error::other(format!(
+        "identity-checked delete refuses to follow reparse point at '{}': remove would unlink the link/junction, not the target.",
+        full_path.display(),
+      )));
+    }
+    // Verify identity on the handle that will perform the delete
+    // — this closes the probe→unlink TOCTOU.
+    // SAFETY: file is alive for the duration of the call.
+    let probe = unsafe { FileIdentity::from_raw_handle(file.as_raw_handle()) }?;
+    if !expected_identity.is_known_equal(&probe) {
+      return Err(Error::other(format!(
+        "cannot unlink '{}': path no longer names the original file (path-reuse detected between handle drop and unlink)",
+        full_path.display(),
+      )));
+    }
+    // Try `FileDispositionInfoEx` first with `POSIX_SEMANTICS |
+    // IGNORE_READONLY_ATTRIBUTE` so readonly files can still be
+    // deleted on Windows 10 1607+.
+    let handle_raw = file.as_raw_handle() as _;
+    let info_ex = FILE_DISPOSITION_INFO_EX {
+      Flags: FILE_DISPOSITION_FLAG_DELETE
+        | FILE_DISPOSITION_FLAG_POSIX_SEMANTICS
+        | FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE,
+    };
+    let ok_ex = unsafe {
+      SetFileInformationByHandle(
+        handle_raw,
+        FileDispositionInfoEx,
+        &info_ex as *const _ as *const _,
+        std::mem::size_of::<FILE_DISPOSITION_INFO_EX>() as u32,
+      )
+    };
+    if ok_ex == 0 {
+      // Legacy fallback for pre-1607 Windows / FAT32 etc.
+      // FileDispositionInfo doesn't bypass readonly, so we explicitly
+      // clear FILE_ATTRIBUTE_READONLY before issuing the legacy
+      // delete. That requires FILE_WRITE_ATTRIBUTES, which the
+      // primary handle doesn't have — re-open via `ReOpenFile` so the
+      // access widening is bound to the same file (handle-based, not
+      // path-based; no TOCTOU).
+      // SAFETY: handle_raw is the live primary handle; ReOpenFile
+      // returns a new HANDLE referring to the same underlying file.
+      let reopen_raw = unsafe {
+        ReOpenFile(
+          handle_raw,
+          DELETE_ACCESS | FILE_WRITE_ATTRIBUTES,
+          FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+          FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+        )
+      };
+      if reopen_raw as isize == INVALID_HANDLE_VALUE {
+        return Err(Error::last_os_error());
+      }
+      // SAFETY: we own reopen_raw exclusively now; wrapping as a
+      // File ensures the handle is closed via Drop on every exit
+      // path (success, error, panic).
+      let reopened = unsafe { std::fs::File::from_raw_handle(reopen_raw as _) };
+      let reopened_raw = reopened.as_raw_handle() as _;
+      let mut basic: FILE_BASIC_INFO = unsafe { std::mem::zeroed() };
+      let ok_get = unsafe {
+        GetFileInformationByHandleEx(
+          reopened_raw,
+          FileBasicInfo,
+          &mut basic as *mut _ as *mut _,
+          std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+      };
+      let was_readonly = ok_get != 0 && (basic.FileAttributes & FILE_ATTRIBUTE_READONLY) != 0;
+      if was_readonly {
+        let mut clear = basic;
+        clear.FileAttributes &= !FILE_ATTRIBUTE_READONLY;
+        // SetFileInformationByHandle treats `FileAttributes == 0`
+        // as "do not change attributes"; if readonly was the only
+        // bit set, our clear would be a no-op.
+        // FILE_ATTRIBUTE_NORMAL (0x80) means "no other attributes
+        // set" and IS a real attribute mutation, so use it as the
+        // sentinel for the readonly-only case.
+        if clear.FileAttributes == 0 {
+          clear.FileAttributes = FILE_ATTRIBUTE_NORMAL;
+        }
+        // If clearing fails, still try disposition — surfaces the
+        // disposition error, more relevant than the attribute-set
+        // error.
+        let _ = unsafe {
+          SetFileInformationByHandle(
+            reopened_raw,
+            FileBasicInfo,
+            &clear as *const _ as *const _,
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+          )
+        };
+      }
+      let info = FILE_DISPOSITION_INFO { DeleteFile: true };
+      let ok = unsafe {
+        SetFileInformationByHandle(
+          reopened_raw,
+          FileDispositionInfo,
+          &info as *const _ as *const _,
+          std::mem::size_of::<FILE_DISPOSITION_INFO>() as u32,
+        )
+      };
+      if ok == 0 {
+        let err = Error::last_os_error();
+        // Restore the readonly bit if disposition failed; the
+        // file still exists on disk.
+        if was_readonly {
+          let _ = unsafe {
+            SetFileInformationByHandle(
+              reopened_raw,
+              FileBasicInfo,
+              &basic as *const _ as *const _,
+              std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+            )
+          };
+        }
+        return Err(err);
+      }
+      drop(reopened);
+    }
+    // Deletion happens on last close. `file` is our only handle
+    // (FILE_SHARE_DELETE was set on open so other readers can hold
+    // their handles); dropping it below triggers actual removal.
+    drop(file);
+    Ok(())
+  }
+  #[cfg(not(any(unix, windows)))]
+  {
+    let _ = (parent, expected_identity);
+    std::fs::remove_file(full_path)
+  }
+}
+
 /// Fsync a pre-opened parent directory handle.
 ///
 /// On POSIX: `sync_all` commits the metadata change (our unlink) for the
@@ -127,90 +392,294 @@ pub(crate) fn sync_parent_handle(parent: &std::fs::File) -> Result<()> {
 }
 
 /// Platform identity of a file, captured once when the file is freshly
-/// opened. Used by all deletion paths to verify that the path still names
-/// the *same* inode before unlinking — otherwise a path-reused file
-/// belonging to another actor could be silently deleted.
+/// opened. Used by every deletion path as a *best-effort path-reuse
+/// mitigation*.
 ///
-/// - POSIX: `(st_dev, st_ino)` from `MetadataExt`. Reliable: a (dev,ino)
-///   pair uniquely identifies an inode while it exists.
-/// - Windows: identity is **unavailable on stable Rust** at this crate's
-///   MSRV (1.75). The natural identity (`GetFileInformationByHandle`'s
-///   file index + volume serial) is exposed via
-///   `std::os::windows::fs::MetadataExt::file_index` /
-///   `volume_serial_number`, both gated behind the unstable
-///   `windows_by_handle` feature (rust-lang/rust#63010) on stable
-///   toolchains. We deliberately do NOT pull in `windows-sys` /
-///   `winapi` to avoid a Windows-only build dep; instead we carry an
-///   empty placeholder and let identity comparisons trivially succeed
-///   on Windows. The path-reuse window between dropping the file
-///   handle and `remove_file` is documented as a known limitation on
-///   Windows.
+/// # What this protects against
+///
+/// The broad window. Between the moment fmmap drops the original `File`
+/// handle and the moment a retry / Drop tries to unlink, arbitrary time
+/// can pass in which another actor may have removed the original file
+/// and put a different one at the same path. The captured identity lets
+/// every later unlink path probe the path, compare, and refuse on
+/// mismatch — closing this *open-ended* race on both POSIX and Windows.
+///
+/// # What this does NOT protect against
+///
+/// **The narrow probe→unlink TOCTOU.** There is no atomic
+/// "unlink-if-inode-matches" primitive in std. Between
+/// `matches_path()` and the subsequent `std::fs::remove_file(path)` an
+/// attacker with sufficient privileges to mutate the parent directory
+/// could swap the entry. The window is one syscall (microseconds);
+/// closing it fully would require platform-specific primitives such as
+/// `unlinkat(parent_fd, basename, 0)` after `fstatat` (POSIX) or
+/// `SetFileInformationByHandle(FileDispositionInfo)` on a handle
+/// opened with `FILE_SHARE_DELETE` (Windows), neither of which std
+/// exposes. We do pin the parent dir handle before unlink so the
+/// post-unlink fsync is durable for the original parent inode, but the
+/// unlink itself remains by-path.
+///
+/// # POSIX inode recycling
+///
+/// The kernel may reuse a recently-freed inode number. In theory a
+/// fresh file at the same path can appear with the *same* `(st_dev,
+/// st_ino)` as the original, defeating the comparison. In practice
+/// this requires the original inode to have been fully released and
+/// the kernel to reallocate that exact number — uncommon outside
+/// small-id filesystems like tmpfs. Holding any handle on the original
+/// inode (e.g. via the parent dir handle we keep around for fsync)
+/// pins it and keeps the kernel from recycling its number.
+///
+/// # Platforms
+///
+/// - **POSIX**: `(st_dev, st_ino)` from `MetadataExt`. A `(dev,ino)` pair
+///   uniquely identifies an inode while it exists.
+/// - **Windows**: `(dwVolumeSerialNumber, nFileIndexHigh:nFileIndexLow)`
+///   from `GetFileInformationByHandle`, via `windows-sys` —
+///   `MetadataExt::file_index` would have required nightly's
+///   `windows_by_handle` feature (rust-lang/rust#63010), so we go
+///   straight to the Win32 API.
+/// - Other targets compile to a placeholder; `is_known_equal` returns
+///   `false` (refuse to identity-delete on platforms we can't verify).
 #[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct FileIdentity {
   #[cfg(unix)]
   dev: u64,
   #[cfg(unix)]
   ino: u64,
-  #[cfg(not(unix))]
+  #[cfg(windows)]
+  volume_serial: u32,
+  #[cfg(windows)]
+  file_index: u64,
+  #[cfg(not(any(unix, windows)))]
   _placeholder: (),
 }
 
 #[cfg(any(feature = "sync", feature = "smol", feature = "tokio"))]
 impl FileIdentity {
-  /// Capture identity from a fresh metadata. The metadata MUST come from
-  /// the open File handle (or its async equivalent), not from a path —
-  /// path-derived metadata is racy with respect to renames.
-  pub(crate) fn from_metadata(meta: &std::fs::Metadata) -> Self {
+  /// Capture identity from an open file handle. POSIX reads
+  /// `Metadata`'s dev+ino; Windows calls `GetFileInformationByHandle`
+  /// on the raw handle to get volume serial + file index.
+  // Live on sync builds (disk/sync_impl.rs) and tests; async paths
+  // use `from_raw_fd`/`from_raw_handle` directly on the borrowed
+  // async file, so the std::fs::File overload is dead under
+  // `--no-default-features --features tokio` / `--features smol`.
+  #[allow(dead_code)]
+  pub(crate) fn from_file(file: &std::fs::File) -> Result<Self> {
     #[cfg(unix)]
     {
       use std::os::unix::fs::MetadataExt;
-      Self {
-        dev: meta.dev(),
-        ino: meta.ino(),
-      }
+      let m = file.metadata()?;
+      Ok(Self {
+        dev: m.dev(),
+        ino: m.ino(),
+      })
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     {
-      let _ = meta;
-      Self { _placeholder: () }
+      use std::os::windows::io::AsRawHandle;
+      // SAFETY: `info` is fully written by GetFileInformationByHandle
+      // when it returns nonzero; we read it only on the success path.
+      let mut info = ::std::mem::MaybeUninit::<
+        ::windows_sys::Win32::Storage::FileSystem::BY_HANDLE_FILE_INFORMATION,
+      >::uninit();
+      let ok = unsafe {
+        ::windows_sys::Win32::Storage::FileSystem::GetFileInformationByHandle(
+          file.as_raw_handle() as ::windows_sys::Win32::Foundation::HANDLE,
+          info.as_mut_ptr(),
+        )
+      };
+      if ok == 0 {
+        return Err(Error::last_os_error());
+      }
+      let info = unsafe { info.assume_init() };
+      let file_index = ((info.nFileIndexHigh as u64) << 32) | (info.nFileIndexLow as u64);
+      Ok(Self {
+        volume_serial: info.dwVolumeSerialNumber,
+        file_index,
+      })
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+      let _ = file;
+      Ok(Self { _placeholder: () })
     }
   }
 
-  /// Strict equality for delete-safety checks. POSIX compares dev+ino.
-  /// On non-POSIX (notably Windows) we have no platform-stable identity
-  /// (see struct doc), so this returns `true` and lets the caller fall
-  /// back to "path exists" semantics — accepting the documented
-  /// path-reuse window as a known limitation.
+  /// Capture identity from a borrowed raw file descriptor (Unix).
+  /// Used by async constructors whose runtime-specific File type isn't
+  /// a `std::fs::File` but exposes `AsRawFd`. Avoids re-opening the
+  /// path (which would race a between-handle-and-probe path swap).
+  ///
+  /// Identity capture is allocation-free. We `fstat` the borrowed fd
+  /// directly — no `dup`, no descriptor allocated. A previous
+  /// implementation applied a destructive `set_len` first and *then*
+  /// dup'd; under fd pressure (EMFILE) the dup would fail and the
+  /// user would get an error after their file had already been
+  /// zeroed. No dup → no fd-allocation failure mode at identity
+  /// capture time.
+  ///
+  /// # Safety
+  /// `fd` must be a valid open file descriptor at call time, with no
+  /// concurrent close.
+  #[cfg(unix)]
+  #[allow(dead_code)] // Only used by async features; sync-only builds skip this.
+  pub(crate) unsafe fn from_raw_fd(fd: std::os::fd::RawFd) -> Result<Self> {
+    use std::os::fd::BorrowedFd;
+    // SAFETY: caller guarantees `fd` is open at call time. We borrow
+    // it only for the duration of `fstat`. No ownership transfer.
+    let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
+    let stat = rustix::fs::fstat(borrowed).map_err(std::io::Error::from)?;
+    Ok(Self {
+      dev: stat.st_dev as u64,
+      ino: stat.st_ino as u64,
+    })
+  }
+
+  /// Capture identity from a borrowed raw OS handle (Windows). See
+  /// `from_raw_fd` for the rationale.
+  ///
+  /// Allocation-free — calls `GetFileInformationByHandle` directly
+  /// on the borrowed handle. A previous implementation used
+  /// `DuplicateHandle` + wrap-as-File + drop, which could fail under
+  /// handle pressure after a destructive `set_len`.
+  ///
+  /// # Safety
+  /// `handle` must be a valid open file HANDLE at call time, with no
+  /// concurrent close.
+  #[cfg(windows)]
+  #[allow(dead_code)] // Only used by async features; sync-only builds skip this.
+  pub(crate) unsafe fn from_raw_handle(handle: std::os::windows::io::RawHandle) -> Result<Self> {
+    use ::windows_sys::Win32::Storage::FileSystem::{
+      GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+    let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+    // SAFETY: caller guarantees `handle` is open at call time.
+    // `GetFileInformationByHandle` reads through the handle without
+    // taking ownership.
+    let ok = unsafe { GetFileInformationByHandle(handle as _, &mut info) };
+    if ok == 0 {
+      return Err(Error::last_os_error());
+    }
+    Ok(Self {
+      volume_serial: info.dwVolumeSerialNumber,
+      file_index: ((info.nFileIndexHigh as u64) << 32) | info.nFileIndexLow as u64,
+    })
+  }
+
+  /// Probe the path's identity without opening the file for I/O.
+  ///
+  /// **Symlinks / reparse points are refused.** `std::fs::remove_file`
+  /// (Unix `unlink`, Windows `DeleteFile`) removes the directory entry
+  /// at `path`, not its target — so even with a matching identity (the
+  /// probe and the original handle both follow to the same target
+  /// inode), unlinking would remove only the symlink/reparse entry
+  /// while leaving the actual mapped file intact. Users who explicitly
+  /// want to remove the link itself should use `std::fs::remove_file`
+  /// directly.
+  ///
+  /// **Unix**: `symlink_metadata` (does not follow links) returns
+  /// dev/ino directly. Stat-only — requires only execute permission on
+  /// the parent dir, not read permission on the file (important so a
+  /// `chmod 000` file in a writable parent is still
+  /// identity-checkable).
+  ///
+  /// **Windows**: open the path with `FILE_FLAG_OPEN_REPARSE_POINT`
+  /// (do not follow the link) and check `FILE_ATTRIBUTE_REPARSE_POINT`
+  /// on the same handle's metadata. This is critical for correctness:
+  /// a separate `symlink_metadata` pre-check followed by a
+  /// reparse-following open is racy — an attacker can swap a regular
+  /// file for a symlink between the two calls and the
+  /// reparse-following open would happily resolve to the original
+  /// target, making the identity match while `remove_file` later
+  /// removes only the swapped-in link. The single-handle check binds
+  /// "is this a reparse point?" to the same syscall as the identity
+  /// probe.
+  // On POSIX the wrappers use `identity_at_or_path` (parent-fd-bound
+  // statat) instead, so this function is dead-code on Unix non-test
+  // builds. Live on Windows and exotic platforms via the
+  // `cfg(not(unix))` fallback in `identity_at_or_path` and the
+  // `cfg(not(any(unix, windows)))` branches in `disk.rs`. Tests use it
+  // on all platforms.
+  #[allow(dead_code)]
+  pub(crate) fn from_path(path: &Path) -> Result<Self> {
+    #[cfg(unix)]
+    {
+      // `symlink_metadata` does NOT follow links; refuse symlinks so
+      // a matching identity doesn't lead to `unlink` removing only
+      // the link entry.
+      let lmeta = std::fs::symlink_metadata(path)?;
+      if lmeta.file_type().is_symlink() {
+        return Err(Error::other(format!(
+          "identity-checked delete refuses to follow symlink at '{}': remove_file would unlink the symlink, not the target. Use std::fs::remove_file or canonicalize the path yourself.",
+          path.display(),
+        )));
+      }
+      use std::os::unix::fs::MetadataExt;
+      Ok(Self {
+        dev: lmeta.dev(),
+        ino: lmeta.ino(),
+      })
+    }
+    #[cfg(windows)]
+    {
+      use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+      const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
+      const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x00200000;
+      const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x00000400;
+      // Open with FILE_FLAG_OPEN_REPARSE_POINT so we get a handle to
+      // the reparse entry itself (if any) instead of the target. Then
+      // refuse if FILE_ATTRIBUTE_REPARSE_POINT is set on the same
+      // handle. Bound to one syscall — no TOCTOU between symlink check
+      // and identity probe.
+      let file = std::fs::OpenOptions::new()
+        .access_mode(0)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+      let meta = file.metadata()?;
+      if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(Error::other(format!(
+          "identity-checked delete refuses to follow reparse point at '{}': remove_file would unlink the link/junction, not the target.",
+          path.display(),
+        )));
+      }
+      Self::from_file(&file)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+      let _ = path;
+      Err(Error::other("FileIdentity unsupported on this platform"))
+    }
+  }
+
+  /// Strict equality for delete-safety checks. Returns `false` on
+  /// platforms without a platform-stable identity (which refuses
+  /// identity-checked deletion rather than silently allowing it).
   pub(crate) fn is_known_equal(&self, other: &Self) -> bool {
     #[cfg(unix)]
     {
       self.dev == other.dev && self.ino == other.ino
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+      self.volume_serial == other.volume_serial && self.file_index == other.file_index
+    }
+    #[cfg(not(any(unix, windows)))]
     {
       let _ = other;
-      true
+      false
     }
   }
 
-  /// Returns `true` iff `path` currently names the same inode as this
-  /// identity. POSIX: stat the path and compare dev+ino. Non-POSIX:
-  /// the best we can do is confirm the path still resolves to *some*
-  /// file — true identity verification needs Windows-specific APIs we
-  /// don't carry (see struct doc).
+  /// Returns `true` iff `path` currently names the same file as this
+  /// identity. Returns `false` on any error (path missing, EACCES,
+  /// etc.) — the conservative default is "do not delete".
+  #[allow(dead_code)] // Test-only on Unix non-default builds.
   pub(crate) fn matches_path(&self, path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-      use std::os::unix::fs::MetadataExt;
-      match std::fs::metadata(path) {
-        Ok(m) => m.dev() == self.dev && m.ino() == self.ino,
-        Err(_) => false,
-      }
-    }
-    #[cfg(not(unix))]
-    {
-      std::fs::metadata(path).is_ok()
+    match Self::from_path(path) {
+      Ok(probe) => self.is_known_equal(&probe),
+      Err(_) => false,
     }
   }
 }


### PR DESCRIPTION
1. (high) Parent fsync retry by path was unsafe: after `remove_file` succeeded but the parent fsync failed, `PendingDelete::NeedsParentSync` stored only the path; a retry re-opened `path.parent()` and fsynced *that*, which would commit metadata on the wrong inode if the parent path was renamed/replaced between unlink and retry — and clear the pending state while the original unlink was never made crash-durable.

   Change `NeedsParentSync(PathBuf)` → `NeedsParentSync { path, parent_handle: std::fs::File }`. The `File` is the same handle that `initial_remove_durably` opened *before* unlinking, so retry's `sync_parent_handle(&parent_handle)` always commits to the original parent inode regardless of subsequent renames. Threaded through: - sync `initial_remove_durably` + `retry_pending_delete` - async `initial_remove_durably_async` + `retry_pending_delete_async` - `drop_complete_pending_delete` The unused `sync_parent_path` / `sync_parent_path_async` helpers are removed.

2. (critical) The stat→`remove_file` TOCTOU is irreducible without atomic unlink-if-inode-matches primitives that std doesn't expose; we don't carry `rustix`/`libc` just for this. Document the narrow one-syscall window prominently in the `FileIdentity` doc comment and in the README, and reframe the public claim from "identity-checked deletion" to "best-effort path-reuse mitigation" so the docs no longer overstate the guarantee.

3. (high) Windows-stable has no real identity (file_index is gated behind nightly's `windows_by_handle` feature, rust-lang/rust#63010, and we don't depend on `windows-sys`). Spell this out in `FileIdentity` doc and in a new README "Path-reuse limitations" section. Add a `#[cfg(windows)]` regression test `windows_path_reuse_is_not_detected_known_limitation` that pins down the current Windows behaviour so a future change cannot silently regress (or improve!) the docs without being noticed.

Sync 92, tokio 64, smol 58, clippy clean, fmt clean.